### PR TITLE
feat(pipelines)!: implement step sequences

### DIFF
--- a/API.md
+++ b/API.md
@@ -146,6 +146,7 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen-pipelines.BashCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 
@@ -170,6 +171,16 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.BashCDKPipeline.property.baseOptions"></a>
+
+```typescript
+public readonly baseOptions: CDKPipelineOptions;
+```
+
+- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -342,6 +353,7 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.CDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.CDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen-pipelines.CDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 
@@ -366,6 +378,16 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.CDKPipeline.property.baseOptions"></a>
+
+```typescript
+public readonly baseOptions: CDKPipelineOptions;
+```
+
+- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -576,6 +598,7 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.needsVersionedArtifacts">needsVersionedArtifacts</a></code> | <code>boolean</code> | *No description.* |
@@ -601,6 +624,16 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.CodeCatalystCDKPipeline.property.baseOptions"></a>
+
+```typescript
+public readonly baseOptions: CDKPipelineOptions;
+```
+
+- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -830,6 +863,7 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen-pipelines.GithubCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.needsVersionedArtifacts">needsVersionedArtifacts</a></code> | <code>boolean</code> | Indicates if versioned artifacts are needed based on manual approval requirements. |
@@ -855,6 +889,16 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.GithubCDKPipeline.property.baseOptions"></a>
+
+```typescript
+public readonly baseOptions: CDKPipelineOptions;
+```
+
+- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -1061,6 +1105,7 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen-pipelines.GitlabCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.config">config</a></code> | <code>projen.gitlab.GitlabConfiguration</code> | GitLab CI/CD configuration object. |
@@ -1088,6 +1133,16 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.GitlabCDKPipeline.property.baseOptions"></a>
+
+```typescript
+public readonly baseOptions: CDKPipelineOptions;
+```
+
+- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -1226,6 +1281,7 @@ const bashCDKPipelineOptions: BashCDKPipelineOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
@@ -1240,6 +1296,18 @@ const bashCDKPipelineOptions: BashCDKPipelineOptions = { ... }
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.preSynthCommands">preSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.preSynthSteps">preSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation. |
+
+---
+
+##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.BashCDKPipelineOptions.property.iamRoleArns"></a>
+
+```typescript
+public readonly iamRoleArns: IamRoleConfig;
+```
+
+- *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
+
+IAM config.
 
 ---
 
@@ -1459,6 +1527,7 @@ const cDKPipelineOptions: CDKPipelineOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen-pipelines.CDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
@@ -1473,6 +1542,18 @@ const cDKPipelineOptions: CDKPipelineOptions = { ... }
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.preSynthCommands">preSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.preSynthSteps">preSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation. |
+
+---
+
+##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.CDKPipelineOptions.property.iamRoleArns"></a>
+
+```typescript
+public readonly iamRoleArns: IamRoleConfig;
+```
+
+- *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
+
+IAM config.
 
 ---
 
@@ -1654,6 +1735,7 @@ const codeCatalystCDKPipelineOptions: CodeCatalystCDKPipelineOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
@@ -1668,7 +1750,18 @@ const codeCatalystCDKPipelineOptions: CodeCatalystCDKPipelineOptions = { ... }
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.preSynthCommands">preSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.preSynthSteps">preSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation. |
-| <code><a href="#projen-pipelines.CodeCatalystCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig">CodeCatalystIamRoleConfig</a></code> | *No description.* |
+
+---
+
+##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.CodeCatalystCDKPipelineOptions.property.iamRoleArns"></a>
+
+```typescript
+public readonly iamRoleArns: IamRoleConfig;
+```
+
+- *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
+
+IAM config.
 
 ---
 
@@ -1836,98 +1929,6 @@ This field is used to define a prefix for the AWS Stack resources created during
 
 ---
 
-##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.CodeCatalystCDKPipelineOptions.property.iamRoleArns"></a>
-
-```typescript
-public readonly iamRoleArns: CodeCatalystIamRoleConfig;
-```
-
-- *Type:* <a href="#projen-pipelines.CodeCatalystIamRoleConfig">CodeCatalystIamRoleConfig</a>
-
----
-
-### CodeCatalystIamRoleConfig <a name="CodeCatalystIamRoleConfig" id="projen-pipelines.CodeCatalystIamRoleConfig"></a>
-
-#### Initializer <a name="Initializer" id="projen-pipelines.CodeCatalystIamRoleConfig.Initializer"></a>
-
-```typescript
-import { CodeCatalystIamRoleConfig } from 'projen-pipelines'
-
-const codeCatalystIamRoleConfig: CodeCatalystIamRoleConfig = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig.property.assetPublishing">assetPublishing</a></code> | <code>string</code> | IAM role ARN for the asset publishing step. |
-| <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig.property.assetPublishingPerStage">assetPublishingPerStage</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARN for the asset publishing step for a specific stage. |
-| <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig.property.default">default</a></code> | <code>string</code> | Default IAM role ARN used if no specific role is provided. |
-| <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig.property.deployment">deployment</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARNs for different deployment stages. |
-| <code><a href="#projen-pipelines.CodeCatalystIamRoleConfig.property.synth">synth</a></code> | <code>string</code> | IAM role ARN for the synthesis step. |
-
----
-
-##### `assetPublishing`<sup>Optional</sup> <a name="assetPublishing" id="projen-pipelines.CodeCatalystIamRoleConfig.property.assetPublishing"></a>
-
-```typescript
-public readonly assetPublishing: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the asset publishing step.
-
----
-
-##### `assetPublishingPerStage`<sup>Optional</sup> <a name="assetPublishingPerStage" id="projen-pipelines.CodeCatalystIamRoleConfig.property.assetPublishingPerStage"></a>
-
-```typescript
-public readonly assetPublishingPerStage: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-IAM role ARN for the asset publishing step for a specific stage.
-
----
-
-##### `default`<sup>Optional</sup> <a name="default" id="projen-pipelines.CodeCatalystIamRoleConfig.property.default"></a>
-
-```typescript
-public readonly default: string;
-```
-
-- *Type:* string
-
-Default IAM role ARN used if no specific role is provided.
-
----
-
-##### `deployment`<sup>Optional</sup> <a name="deployment" id="projen-pipelines.CodeCatalystIamRoleConfig.property.deployment"></a>
-
-```typescript
-public readonly deployment: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-IAM role ARNs for different deployment stages.
-
----
-
-##### `synth`<sup>Optional</sup> <a name="synth" id="projen-pipelines.CodeCatalystIamRoleConfig.property.synth"></a>
-
-```typescript
-public readonly synth: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the synthesis step.
-
----
-
 ### CodeCatalystStepConfig <a name="CodeCatalystStepConfig" id="projen-pipelines.CodeCatalystStepConfig"></a>
 
 Configuration interface for a CodeCatalyst Actions step.
@@ -2004,6 +2005,8 @@ const deploymentStage: DeploymentStage = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.DeploymentStage.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.DeploymentStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.DeploymentStage.property.postDeploySteps">postDeploySteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
+| <code><a href="#projen-pipelines.DeploymentStage.property.postDiffSteps">postDiffSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.DeploymentStage.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#projen-pipelines.DeploymentStage.property.manualApproval">manualApproval</a></code> | <code>boolean</code> | *No description.* |
 
@@ -2026,6 +2029,26 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `postDeploySteps`<sup>Optional</sup> <a name="postDeploySteps" id="projen-pipelines.DeploymentStage.property.postDeploySteps"></a>
+
+```typescript
+public readonly postDeploySteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+
+---
+
+##### `postDiffSteps`<sup>Optional</sup> <a name="postDiffSteps" id="projen-pipelines.DeploymentStage.property.postDiffSteps"></a>
+
+```typescript
+public readonly postDiffSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
 
 ---
 
@@ -2159,6 +2182,7 @@ const githubCDKPipelineOptions: GithubCDKPipelineOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
@@ -2173,10 +2197,21 @@ const githubCDKPipelineOptions: GithubCDKPipelineOptions = { ... }
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.preSynthCommands">preSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.preSynthSteps">preSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation. |
-| <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.GithubIamRoleConfig">GithubIamRoleConfig</a></code> | IAM config for GitHub Actions. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.runnerTags">runnerTags</a></code> | <code>string[]</code> | runner tags to use to select runners. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.useGithubEnvironments">useGithubEnvironments</a></code> | <code>boolean</code> | whether to use GitHub environments for deployment stages. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.useGithubPackagesForAssembly">useGithubPackagesForAssembly</a></code> | <code>boolean</code> | use GitHub Packages to store vesioned artifacts of cloud assembly; |
+
+---
+
+##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.GithubCDKPipelineOptions.property.iamRoleArns"></a>
+
+```typescript
+public readonly iamRoleArns: IamRoleConfig;
+```
+
+- *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
+
+IAM config.
 
 ---
 
@@ -2344,18 +2379,6 @@ This field is used to define a prefix for the AWS Stack resources created during
 
 ---
 
-##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.GithubCDKPipelineOptions.property.iamRoleArns"></a>
-
-```typescript
-public readonly iamRoleArns: GithubIamRoleConfig;
-```
-
-- *Type:* <a href="#projen-pipelines.GithubIamRoleConfig">GithubIamRoleConfig</a>
-
-IAM config for GitHub Actions.
-
----
-
 ##### `runnerTags`<sup>Optional</sup> <a name="runnerTags" id="projen-pipelines.GithubCDKPipelineOptions.property.runnerTags"></a>
 
 ```typescript
@@ -2395,90 +2418,6 @@ public readonly useGithubPackagesForAssembly: boolean;
 use GitHub Packages to store vesioned artifacts of cloud assembly;
 
 also needed for manual approvals
-
----
-
-### GithubIamRoleConfig <a name="GithubIamRoleConfig" id="projen-pipelines.GithubIamRoleConfig"></a>
-
-Configuration interface for GitHub-specific IAM roles used in the CDK pipeline.
-
-#### Initializer <a name="Initializer" id="projen-pipelines.GithubIamRoleConfig.Initializer"></a>
-
-```typescript
-import { GithubIamRoleConfig } from 'projen-pipelines'
-
-const githubIamRoleConfig: GithubIamRoleConfig = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#projen-pipelines.GithubIamRoleConfig.property.assetPublishing">assetPublishing</a></code> | <code>string</code> | IAM role ARN for the asset publishing step. |
-| <code><a href="#projen-pipelines.GithubIamRoleConfig.property.assetPublishingPerStage">assetPublishingPerStage</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARN for the asset publishing step for a specific stage. |
-| <code><a href="#projen-pipelines.GithubIamRoleConfig.property.default">default</a></code> | <code>string</code> | Default IAM role ARN used if no specific role is provided. |
-| <code><a href="#projen-pipelines.GithubIamRoleConfig.property.deployment">deployment</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARNs for different deployment stages. |
-| <code><a href="#projen-pipelines.GithubIamRoleConfig.property.synth">synth</a></code> | <code>string</code> | IAM role ARN for the synthesis step. |
-
----
-
-##### `assetPublishing`<sup>Optional</sup> <a name="assetPublishing" id="projen-pipelines.GithubIamRoleConfig.property.assetPublishing"></a>
-
-```typescript
-public readonly assetPublishing: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the asset publishing step.
-
----
-
-##### `assetPublishingPerStage`<sup>Optional</sup> <a name="assetPublishingPerStage" id="projen-pipelines.GithubIamRoleConfig.property.assetPublishingPerStage"></a>
-
-```typescript
-public readonly assetPublishingPerStage: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-IAM role ARN for the asset publishing step for a specific stage.
-
----
-
-##### `default`<sup>Optional</sup> <a name="default" id="projen-pipelines.GithubIamRoleConfig.property.default"></a>
-
-```typescript
-public readonly default: string;
-```
-
-- *Type:* string
-
-Default IAM role ARN used if no specific role is provided.
-
----
-
-##### `deployment`<sup>Optional</sup> <a name="deployment" id="projen-pipelines.GithubIamRoleConfig.property.deployment"></a>
-
-```typescript
-public readonly deployment: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-IAM role ARNs for different deployment stages.
-
----
-
-##### `synth`<sup>Optional</sup> <a name="synth" id="projen-pipelines.GithubIamRoleConfig.property.synth"></a>
-
-```typescript
-public readonly synth: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the synthesis step.
 
 ---
 
@@ -2600,6 +2539,7 @@ const gitlabCDKPipelineOptions: GitlabCDKPipelineOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
@@ -2614,9 +2554,20 @@ const gitlabCDKPipelineOptions: GitlabCDKPipelineOptions = { ... }
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.preSynthCommands">preSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.preSynthSteps">preSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation. |
-| <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.GitlabIamRoleConfig">GitlabIamRoleConfig</a></code> | IAM role ARNs configuration for the pipeline. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.image">image</a></code> | <code>string</code> | The Docker image to use for running the pipeline jobs. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.runnerTags">runnerTags</a></code> | <code><a href="#projen-pipelines.GitlabRunnerTags">GitlabRunnerTags</a></code> | Runner tags configuration for the pipeline. |
+
+---
+
+##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.GitlabCDKPipelineOptions.property.iamRoleArns"></a>
+
+```typescript
+public readonly iamRoleArns: IamRoleConfig;
+```
+
+- *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
+
+IAM config.
 
 ---
 
@@ -2784,18 +2735,6 @@ This field is used to define a prefix for the AWS Stack resources created during
 
 ---
 
-##### `iamRoleArns`<sup>Required</sup> <a name="iamRoleArns" id="projen-pipelines.GitlabCDKPipelineOptions.property.iamRoleArns"></a>
-
-```typescript
-public readonly iamRoleArns: GitlabIamRoleConfig;
-```
-
-- *Type:* <a href="#projen-pipelines.GitlabIamRoleConfig">GitlabIamRoleConfig</a>
-
-IAM role ARNs configuration for the pipeline.
-
----
-
 ##### `image`<sup>Optional</sup> <a name="image" id="projen-pipelines.GitlabCDKPipelineOptions.property.image"></a>
 
 ```typescript
@@ -2817,106 +2756,6 @@ public readonly runnerTags: GitlabRunnerTags;
 - *Type:* <a href="#projen-pipelines.GitlabRunnerTags">GitlabRunnerTags</a>
 
 Runner tags configuration for the pipeline.
-
----
-
-### GitlabIamRoleConfig <a name="GitlabIamRoleConfig" id="projen-pipelines.GitlabIamRoleConfig"></a>
-
-Configuration for IAM roles used within the GitLab CI/CD pipeline for various stages.
-
-Allows specifying different IAM roles for synthesis, asset publishing, and deployment stages,
-providing granular control over permissions.
-
-#### Initializer <a name="Initializer" id="projen-pipelines.GitlabIamRoleConfig.Initializer"></a>
-
-```typescript
-import { GitlabIamRoleConfig } from 'projen-pipelines'
-
-const gitlabIamRoleConfig: GitlabIamRoleConfig = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.assetPublishing">assetPublishing</a></code> | <code>string</code> | IAM role ARN for the asset publishing step. |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.assetPublishingPerStage">assetPublishingPerStage</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARN for the asset publishing step for a specific stage. |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.default">default</a></code> | <code>string</code> | Default IAM role ARN used if specific stage role is not provided. |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.deployment">deployment</a></code> | <code>{[ key: string ]: string}</code> | A map of stage names to IAM role ARNs for the deployment operation. |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.diff">diff</a></code> | <code>{[ key: string ]: string}</code> | A map of stage names to IAM role ARNs for the diff operation. |
-| <code><a href="#projen-pipelines.GitlabIamRoleConfig.property.synth">synth</a></code> | <code>string</code> | IAM role ARN for the synthesis stage. |
-
----
-
-##### `assetPublishing`<sup>Optional</sup> <a name="assetPublishing" id="projen-pipelines.GitlabIamRoleConfig.property.assetPublishing"></a>
-
-```typescript
-public readonly assetPublishing: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the asset publishing step.
-
----
-
-##### `assetPublishingPerStage`<sup>Optional</sup> <a name="assetPublishingPerStage" id="projen-pipelines.GitlabIamRoleConfig.property.assetPublishingPerStage"></a>
-
-```typescript
-public readonly assetPublishingPerStage: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-IAM role ARN for the asset publishing step for a specific stage.
-
----
-
-##### `default`<sup>Optional</sup> <a name="default" id="projen-pipelines.GitlabIamRoleConfig.property.default"></a>
-
-```typescript
-public readonly default: string;
-```
-
-- *Type:* string
-
-Default IAM role ARN used if specific stage role is not provided.
-
----
-
-##### `deployment`<sup>Optional</sup> <a name="deployment" id="projen-pipelines.GitlabIamRoleConfig.property.deployment"></a>
-
-```typescript
-public readonly deployment: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-A map of stage names to IAM role ARNs for the deployment operation.
-
----
-
-##### `diff`<sup>Optional</sup> <a name="diff" id="projen-pipelines.GitlabIamRoleConfig.property.diff"></a>
-
-```typescript
-public readonly diff: {[ key: string ]: string};
-```
-
-- *Type:* {[ key: string ]: string}
-
-A map of stage names to IAM role ARNs for the diff operation.
-
----
-
-##### `synth`<sup>Optional</sup> <a name="synth" id="projen-pipelines.GitlabIamRoleConfig.property.synth"></a>
-
-```typescript
-public readonly synth: string;
-```
-
-- *Type:* string
-
-IAM role ARN for the synthesis stage.
 
 ---
 
@@ -3077,6 +2916,103 @@ Dependencies which need to be completed before this step.
 
 ---
 
+### IamRoleConfig <a name="IamRoleConfig" id="projen-pipelines.IamRoleConfig"></a>
+
+Configuration interface for IAM roles used in the CDK pipeline.
+
+#### Initializer <a name="Initializer" id="projen-pipelines.IamRoleConfig.Initializer"></a>
+
+```typescript
+import { IamRoleConfig } from 'projen-pipelines'
+
+const iamRoleConfig: IamRoleConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.assetPublishing">assetPublishing</a></code> | <code>string</code> | IAM role ARN for the asset publishing step. |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.assetPublishingPerStage">assetPublishingPerStage</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARN for the asset publishing step for a specific stage. |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.default">default</a></code> | <code>string</code> | Default IAM role ARN used if no specific role is provided. |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.deployment">deployment</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARNs for different deployment stages. |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.diff">diff</a></code> | <code>{[ key: string ]: string}</code> | IAM role ARNs for different diff stages. |
+| <code><a href="#projen-pipelines.IamRoleConfig.property.synth">synth</a></code> | <code>string</code> | IAM role ARN for the synthesis step. |
+
+---
+
+##### `assetPublishing`<sup>Optional</sup> <a name="assetPublishing" id="projen-pipelines.IamRoleConfig.property.assetPublishing"></a>
+
+```typescript
+public readonly assetPublishing: string;
+```
+
+- *Type:* string
+
+IAM role ARN for the asset publishing step.
+
+---
+
+##### `assetPublishingPerStage`<sup>Optional</sup> <a name="assetPublishingPerStage" id="projen-pipelines.IamRoleConfig.property.assetPublishingPerStage"></a>
+
+```typescript
+public readonly assetPublishingPerStage: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+IAM role ARN for the asset publishing step for a specific stage.
+
+---
+
+##### `default`<sup>Optional</sup> <a name="default" id="projen-pipelines.IamRoleConfig.property.default"></a>
+
+```typescript
+public readonly default: string;
+```
+
+- *Type:* string
+
+Default IAM role ARN used if no specific role is provided.
+
+---
+
+##### `deployment`<sup>Optional</sup> <a name="deployment" id="projen-pipelines.IamRoleConfig.property.deployment"></a>
+
+```typescript
+public readonly deployment: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+IAM role ARNs for different deployment stages.
+
+---
+
+##### `diff`<sup>Optional</sup> <a name="diff" id="projen-pipelines.IamRoleConfig.property.diff"></a>
+
+```typescript
+public readonly diff: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+IAM role ARNs for different diff stages.
+
+---
+
+##### `synth`<sup>Optional</sup> <a name="synth" id="projen-pipelines.IamRoleConfig.property.synth"></a>
+
+```typescript
+public readonly synth: string;
+```
+
+- *Type:* string
+
+IAM role ARN for the synthesis step.
+
+---
+
 ### IndependentStage <a name="IndependentStage" id="projen-pipelines.IndependentStage"></a>
 
 Options for stages that are not part of the pipeline.
@@ -3095,10 +3031,10 @@ const independentStage: IndependentStage = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.IndependentStage.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.IndependentStage.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#projen-pipelines.IndependentStage.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#projen-pipelines.IndependentStage.property.deployOnPush">deployOnPush</a></code> | <code>boolean</code> | This specifies whether the stage should be deployed on push. |
 | <code><a href="#projen-pipelines.IndependentStage.property.postDeploySteps">postDeploySteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.IndependentStage.property.postDiffSteps">postDiffSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
+| <code><a href="#projen-pipelines.IndependentStage.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#projen-pipelines.IndependentStage.property.deployOnPush">deployOnPush</a></code> | <code>boolean</code> | This specifies whether the stage should be deployed on push. |
 
 ---
 
@@ -3119,6 +3055,26 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `postDeploySteps`<sup>Optional</sup> <a name="postDeploySteps" id="projen-pipelines.IndependentStage.property.postDeploySteps"></a>
+
+```typescript
+public readonly postDeploySteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+
+---
+
+##### `postDiffSteps`<sup>Optional</sup> <a name="postDiffSteps" id="projen-pipelines.IndependentStage.property.postDiffSteps"></a>
+
+```typescript
+public readonly postDiffSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
 
 ---
 
@@ -3145,26 +3101,6 @@ This specifies whether the stage should be deployed on push.
 
 ---
 
-##### `postDeploySteps`<sup>Optional</sup> <a name="postDeploySteps" id="projen-pipelines.IndependentStage.property.postDeploySteps"></a>
-
-```typescript
-public readonly postDeploySteps: PipelineStep[];
-```
-
-- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
-
----
-
-##### `postDiffSteps`<sup>Optional</sup> <a name="postDiffSteps" id="projen-pipelines.IndependentStage.property.postDiffSteps"></a>
-
-```typescript
-public readonly postDiffSteps: PipelineStep[];
-```
-
-- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
-
----
-
 ### NamedStageOptions <a name="NamedStageOptions" id="projen-pipelines.NamedStageOptions"></a>
 
 Options for a CDK stage with a name.
@@ -3183,6 +3119,8 @@ const namedStageOptions: NamedStageOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.NamedStageOptions.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.NamedStageOptions.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.NamedStageOptions.property.postDeploySteps">postDeploySteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
+| <code><a href="#projen-pipelines.NamedStageOptions.property.postDiffSteps">postDiffSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.NamedStageOptions.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
 
 ---
@@ -3204,6 +3142,26 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `postDeploySteps`<sup>Optional</sup> <a name="postDeploySteps" id="projen-pipelines.NamedStageOptions.property.postDeploySteps"></a>
+
+```typescript
+public readonly postDeploySteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+
+---
+
+##### `postDiffSteps`<sup>Optional</sup> <a name="postDiffSteps" id="projen-pipelines.NamedStageOptions.property.postDiffSteps"></a>
+
+```typescript
+public readonly postDiffSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
 
 ---
 
@@ -3623,6 +3581,90 @@ Should be implemented by subclasses.
 
 
 
+### ProjenScriptStep <a name="ProjenScriptStep" id="projen-pipelines.ProjenScriptStep"></a>
+
+#### Initializers <a name="Initializers" id="projen-pipelines.ProjenScriptStep.Initializer"></a>
+
+```typescript
+import { ProjenScriptStep } from 'projen-pipelines'
+
+new ProjenScriptStep(project: Project, scriptName: string, args?: string)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.ProjenScriptStep.Initializer.parameter.project">project</a></code> | <code>projen.Project</code> | - The projen project reference. |
+| <code><a href="#projen-pipelines.ProjenScriptStep.Initializer.parameter.scriptName">scriptName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.ProjenScriptStep.Initializer.parameter.args">args</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen-pipelines.ProjenScriptStep.Initializer.parameter.project"></a>
+
+- *Type:* projen.Project
+
+The projen project reference.
+
+---
+
+##### `scriptName`<sup>Required</sup> <a name="scriptName" id="projen-pipelines.ProjenScriptStep.Initializer.parameter.scriptName"></a>
+
+- *Type:* string
+
+---
+
+##### `args`<sup>Optional</sup> <a name="args" id="projen-pipelines.ProjenScriptStep.Initializer.parameter.args"></a>
+
+- *Type:* string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen-pipelines.ProjenScriptStep.toBash">toBash</a></code> | Converts the step into a Bash script configuration. |
+| <code><a href="#projen-pipelines.ProjenScriptStep.toCodeCatalyst">toCodeCatalyst</a></code> | Converts the step into a CodeCatalyst Actions step configuration. |
+| <code><a href="#projen-pipelines.ProjenScriptStep.toGithub">toGithub</a></code> | Converts the step into a GitHub Actions step configuration. |
+| <code><a href="#projen-pipelines.ProjenScriptStep.toGitlab">toGitlab</a></code> | Converts the step into a GitLab CI configuration. |
+
+---
+
+##### `toBash` <a name="toBash" id="projen-pipelines.ProjenScriptStep.toBash"></a>
+
+```typescript
+public toBash(): BashStepConfig
+```
+
+Converts the step into a Bash script configuration.
+
+##### `toCodeCatalyst` <a name="toCodeCatalyst" id="projen-pipelines.ProjenScriptStep.toCodeCatalyst"></a>
+
+```typescript
+public toCodeCatalyst(): CodeCatalystStepConfig
+```
+
+Converts the step into a CodeCatalyst Actions step configuration.
+
+##### `toGithub` <a name="toGithub" id="projen-pipelines.ProjenScriptStep.toGithub"></a>
+
+```typescript
+public toGithub(): GithubStepConfig
+```
+
+Converts the step into a GitHub Actions step configuration.
+
+##### `toGitlab` <a name="toGitlab" id="projen-pipelines.ProjenScriptStep.toGitlab"></a>
+
+```typescript
+public toGitlab(): GitlabStepConfig
+```
+
+Converts the step into a GitLab CI configuration.
+
+
+
+
 ### SimpleCommandStep <a name="SimpleCommandStep" id="projen-pipelines.SimpleCommandStep"></a>
 
 Concrete implementation of PipelineStep that executes simple commands.
@@ -3700,6 +3742,111 @@ public toGitlab(): GitlabStepConfig
 ```
 
 Converts the step into a GitLab CI configuration.
+
+
+
+
+### StepSequence <a name="StepSequence" id="projen-pipelines.StepSequence"></a>
+
+#### Initializers <a name="Initializers" id="projen-pipelines.StepSequence.Initializer"></a>
+
+```typescript
+import { StepSequence } from 'projen-pipelines'
+
+new StepSequence(project: Project, steps: PipelineStep[])
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.StepSequence.Initializer.parameter.project">project</a></code> | <code>projen.Project</code> | - The projen project reference. |
+| <code><a href="#projen-pipelines.StepSequence.Initializer.parameter.steps">steps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | - The sequence of pipeline steps. |
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen-pipelines.StepSequence.Initializer.parameter.project"></a>
+
+- *Type:* projen.Project
+
+The projen project reference.
+
+---
+
+##### `steps`<sup>Required</sup> <a name="steps" id="projen-pipelines.StepSequence.Initializer.parameter.steps"></a>
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+
+The sequence of pipeline steps.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen-pipelines.StepSequence.toBash">toBash</a></code> | Converts the sequence of steps into a Bash script configuration. |
+| <code><a href="#projen-pipelines.StepSequence.toCodeCatalyst">toCodeCatalyst</a></code> | Converts the sequence of steps into a CodeCatalyst Actions step configuration. |
+| <code><a href="#projen-pipelines.StepSequence.toGithub">toGithub</a></code> | Converts the sequence of steps into a GitHub Actions step configuration. |
+| <code><a href="#projen-pipelines.StepSequence.toGitlab">toGitlab</a></code> | Converts the sequence of steps into a GitLab CI configuration. |
+| <code><a href="#projen-pipelines.StepSequence.addSteps">addSteps</a></code> | *No description.* |
+| <code><a href="#projen-pipelines.StepSequence.prependSteps">prependSteps</a></code> | *No description.* |
+
+---
+
+##### `toBash` <a name="toBash" id="projen-pipelines.StepSequence.toBash"></a>
+
+```typescript
+public toBash(): BashStepConfig
+```
+
+Converts the sequence of steps into a Bash script configuration.
+
+##### `toCodeCatalyst` <a name="toCodeCatalyst" id="projen-pipelines.StepSequence.toCodeCatalyst"></a>
+
+```typescript
+public toCodeCatalyst(): CodeCatalystStepConfig
+```
+
+Converts the sequence of steps into a CodeCatalyst Actions step configuration.
+
+##### `toGithub` <a name="toGithub" id="projen-pipelines.StepSequence.toGithub"></a>
+
+```typescript
+public toGithub(): GithubStepConfig
+```
+
+Converts the sequence of steps into a GitHub Actions step configuration.
+
+##### `toGitlab` <a name="toGitlab" id="projen-pipelines.StepSequence.toGitlab"></a>
+
+```typescript
+public toGitlab(): GitlabStepConfig
+```
+
+Converts the sequence of steps into a GitLab CI configuration.
+
+##### `addSteps` <a name="addSteps" id="projen-pipelines.StepSequence.addSteps"></a>
+
+```typescript
+public addSteps(steps: PipelineStep): void
+```
+
+###### `steps`<sup>Required</sup> <a name="steps" id="projen-pipelines.StepSequence.addSteps.parameter.steps"></a>
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>
+
+---
+
+##### `prependSteps` <a name="prependSteps" id="projen-pipelines.StepSequence.prependSteps"></a>
+
+```typescript
+public prependSteps(steps: PipelineStep): void
+```
+
+###### `steps`<sup>Required</sup> <a name="steps" id="projen-pipelines.StepSequence.prependSteps.parameter.steps"></a>
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>
+
+---
 
 
 

--- a/API.md
+++ b/API.md
@@ -146,7 +146,6 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen-pipelines.BashCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 
@@ -171,16 +170,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.BashCDKPipeline.property.baseOptions"></a>
-
-```typescript
-public readonly baseOptions: CDKPipelineOptions;
-```
-
-- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -353,7 +342,6 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.CDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.CDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen-pipelines.CDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 
@@ -378,16 +366,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.CDKPipeline.property.baseOptions"></a>
-
-```typescript
-public readonly baseOptions: CDKPipelineOptions;
-```
-
-- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -598,7 +576,6 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeCatalystCDKPipeline.property.needsVersionedArtifacts">needsVersionedArtifacts</a></code> | <code>boolean</code> | *No description.* |
@@ -624,16 +601,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.CodeCatalystCDKPipeline.property.baseOptions"></a>
-
-```typescript
-public readonly baseOptions: CDKPipelineOptions;
-```
-
-- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -863,7 +830,6 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen-pipelines.GithubCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipeline.property.needsVersionedArtifacts">needsVersionedArtifacts</a></code> | <code>boolean</code> | Indicates if versioned artifacts are needed based on manual approval requirements. |
@@ -889,16 +855,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.GithubCDKPipeline.property.baseOptions"></a>
-
-```typescript
-public readonly baseOptions: CDKPipelineOptions;
-```
-
-- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -1105,7 +1061,6 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen-pipelines.GitlabCDKPipeline.property.baseOptions">baseOptions</a></code> | <code><a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.branchName">branchName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.stackPrefix">stackPrefix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipeline.property.config">config</a></code> | <code>projen.gitlab.GitlabConfiguration</code> | GitLab CI/CD configuration object. |
@@ -1133,16 +1088,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `baseOptions`<sup>Required</sup> <a name="baseOptions" id="projen-pipelines.GitlabCDKPipeline.property.baseOptions"></a>
-
-```typescript
-public readonly baseOptions: CDKPipelineOptions;
-```
-
-- *Type:* <a href="#projen-pipelines.CDKPipelineOptions">CDKPipelineOptions</a>
 
 ---
 
@@ -1718,6 +1663,67 @@ public readonly stackPrefix: string;
 - *Default:* project name
 
 This field is used to define a prefix for the AWS Stack resources created during the pipeline's operation.
+
+---
+
+### CodeArtifactLoginStepOptions <a name="CodeArtifactLoginStepOptions" id="projen-pipelines.CodeArtifactLoginStepOptions"></a>
+
+#### Initializer <a name="Initializer" id="projen-pipelines.CodeArtifactLoginStepOptions.Initializer"></a>
+
+```typescript
+import { CodeArtifactLoginStepOptions } from 'projen-pipelines'
+
+const codeArtifactLoginStepOptions: CodeArtifactLoginStepOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.domainName">domainName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.ownerAccount">ownerAccount</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.region">region</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.role">role</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `domainName`<sup>Required</sup> <a name="domainName" id="projen-pipelines.CodeArtifactLoginStepOptions.property.domainName"></a>
+
+```typescript
+public readonly domainName: string;
+```
+
+- *Type:* string
+
+---
+
+##### `ownerAccount`<sup>Required</sup> <a name="ownerAccount" id="projen-pipelines.CodeArtifactLoginStepOptions.property.ownerAccount"></a>
+
+```typescript
+public readonly ownerAccount: string;
+```
+
+- *Type:* string
+
+---
+
+##### `region`<sup>Required</sup> <a name="region" id="projen-pipelines.CodeArtifactLoginStepOptions.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+
+---
+
+##### `role`<sup>Required</sup> <a name="role" id="projen-pipelines.CodeArtifactLoginStepOptions.property.role"></a>
+
+```typescript
+public readonly role: string;
+```
+
+- *Type:* string
 
 ---
 
@@ -3329,6 +3335,109 @@ public toGitlab(): GitlabStepConfig
 Generates a configuration for a GitLab CI step.
 
 Should be implemented by subclasses.
+
+
+
+
+### CodeArtifactLoginStep <a name="CodeArtifactLoginStep" id="projen-pipelines.CodeArtifactLoginStep"></a>
+
+#### Initializers <a name="Initializers" id="projen-pipelines.CodeArtifactLoginStep.Initializer"></a>
+
+```typescript
+import { CodeArtifactLoginStep } from 'projen-pipelines'
+
+new CodeArtifactLoginStep(project: Project, options: CodeArtifactLoginStepOptions)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.Initializer.parameter.project">project</a></code> | <code>projen.Project</code> | - The projen project reference. |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.Initializer.parameter.options">options</a></code> | <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions">CodeArtifactLoginStepOptions</a></code> | *No description.* |
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen-pipelines.CodeArtifactLoginStep.Initializer.parameter.project"></a>
+
+- *Type:* projen.Project
+
+The projen project reference.
+
+---
+
+##### `options`<sup>Required</sup> <a name="options" id="projen-pipelines.CodeArtifactLoginStep.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#projen-pipelines.CodeArtifactLoginStepOptions">CodeArtifactLoginStepOptions</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.toBash">toBash</a></code> | Converts the sequence of steps into a Bash script configuration. |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.toCodeCatalyst">toCodeCatalyst</a></code> | Converts the sequence of steps into a CodeCatalyst Actions step configuration. |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.toGithub">toGithub</a></code> | Converts the sequence of steps into a GitHub Actions step configuration. |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.toGitlab">toGitlab</a></code> | Converts the sequence of steps into a GitLab CI configuration. |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.addSteps">addSteps</a></code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStep.prependSteps">prependSteps</a></code> | *No description.* |
+
+---
+
+##### `toBash` <a name="toBash" id="projen-pipelines.CodeArtifactLoginStep.toBash"></a>
+
+```typescript
+public toBash(): BashStepConfig
+```
+
+Converts the sequence of steps into a Bash script configuration.
+
+##### `toCodeCatalyst` <a name="toCodeCatalyst" id="projen-pipelines.CodeArtifactLoginStep.toCodeCatalyst"></a>
+
+```typescript
+public toCodeCatalyst(): CodeCatalystStepConfig
+```
+
+Converts the sequence of steps into a CodeCatalyst Actions step configuration.
+
+##### `toGithub` <a name="toGithub" id="projen-pipelines.CodeArtifactLoginStep.toGithub"></a>
+
+```typescript
+public toGithub(): GithubStepConfig
+```
+
+Converts the sequence of steps into a GitHub Actions step configuration.
+
+##### `toGitlab` <a name="toGitlab" id="projen-pipelines.CodeArtifactLoginStep.toGitlab"></a>
+
+```typescript
+public toGitlab(): GitlabStepConfig
+```
+
+Converts the sequence of steps into a GitLab CI configuration.
+
+##### `addSteps` <a name="addSteps" id="projen-pipelines.CodeArtifactLoginStep.addSteps"></a>
+
+```typescript
+public addSteps(steps: PipelineStep): void
+```
+
+###### `steps`<sup>Required</sup> <a name="steps" id="projen-pipelines.CodeArtifactLoginStep.addSteps.parameter.steps"></a>
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>
+
+---
+
+##### `prependSteps` <a name="prependSteps" id="projen-pipelines.CodeArtifactLoginStep.prependSteps"></a>
+
+```typescript
+public prependSteps(steps: PipelineStep): void
+```
+
+###### `steps`<sup>Required</sup> <a name="steps" id="projen-pipelines.CodeArtifactLoginStep.prependSteps.parameter.steps"></a>
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>
+
+---
 
 
 

--- a/src/awscdk/bash.ts
+++ b/src/awscdk/bash.ts
@@ -20,27 +20,22 @@ export class BashCDKPipeline extends CDKPipeline {
 
     readme.addLine('Synthesize your CDK project:');
     readme.addLine('```bash');
-    readme.addLine(`${(options.preInstallSteps ?? []).flatMap(s => s.toBash().commands).join('\n')}`);
-    readme.addLine(`${this.renderInstallCommands().join('\n')}`);
-    readme.addLine(`${(options.preSynthSteps ?? []).flatMap(s => s.toBash().commands).join('\n')}`);
-    readme.addLine(`${this.renderSynthCommands().join('\n')}`);
-    readme.addLine(`${(options.postSynthSteps ?? []).flatMap(s => s.toBash().commands).join('\n')}`);
+    readme.addLine(`${this.provideInstallStep().toBash().commands.join('\n')}`);
+    readme.addLine(`${this.provideSynthStep().toBash().commands.join('\n')}`);
     readme.addLine('```');
     readme.addLine('');
 
     readme.addLine('Publish all your CDK assets like Lambda function code and container images:');
     readme.addLine('```bash');
-    readme.addLine(`${(options.preInstallSteps ?? []).flatMap(s => s.toBash().commands).join('\n')}`);
-    readme.addLine(`${this.renderInstallCommands().join('\n')}`);
-    readme.addLine(`${this.renderAssetUploadCommands().join('\n')}`);
+    readme.addLine(`${this.provideInstallStep().toBash().commands.join('\n')}`);
+    readme.addLine(`${this.provideAssetUploadStep().toBash().commands.join('\n')}`);
     readme.addLine('```');
     readme.addLine('');
     readme.addLine('If you want to store your cloud assembly and assets for future use or compliance reasons, use:');
     readme.addLine('```bash');
-    readme.addLine(`${(options.preInstallSteps ?? []).flatMap(s => s.toBash().commands).join('\n')}`);
-    readme.addLine(`${this.renderInstallCommands().join('\n')}`);
-    readme.addLine(`${this.renderAssetUploadCommands().join('\n')}`);
-    readme.addLine(`${this.renderAssemblyUploadCommands().join('\n')}`);
+    readme.addLine(`${this.provideInstallStep().toBash().commands.join('\n')}`);
+    readme.addLine(`${this.provideAssetUploadStep().toBash().commands.join('\n')}`);
+    readme.addLine(`${this.provideAssemblyUploadStep().toBash().commands.join('\n')}`);
     readme.addLine('```');
     readme.addLine('');
     readme.addLine('## Deployment phase');
@@ -51,9 +46,9 @@ export class BashCDKPipeline extends CDKPipeline {
     for (const stage of options.stages) {
       readme.addLine(`Stage: ${stage.name}`);
       readme.addLine('```bash');
-      readme.addLine(`${this.renderDiffCommands(stage.name).join('\n')}`);
+      readme.addLine(`${this.provideDiffStep(stage).toBash().commands.join('\n')}`);
       readme.addLine('');
-      readme.addLine(`${this.renderDeployCommands(stage.name).join('\n')}`);
+      readme.addLine(`${this.provideDeployStep(stage).toBash().commands.join('\n')}`);
       readme.addLine('```');
       readme.addLine('');
     }

--- a/src/steps/aws-assume-role.step.ts
+++ b/src/steps/aws-assume-role.step.ts
@@ -1,6 +1,6 @@
 import { Project } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
-import { GithubStepConfig, GitlabStepConfig, PipelineStep } from './step';
+import { BashStepConfig, CodeCatalystStepConfig, GithubStepConfig, GitlabStepConfig, PipelineStep } from './step';
 
 
 /**
@@ -53,6 +53,23 @@ export class AwsAssumeRoleStep extends PipelineStep {
       permissions: {
         idToken: JobPermission.WRITE,
       },
+    };
+  }
+
+  public toBash(): BashStepConfig {
+    return {
+      commands: [
+        `echo "Login to AWS using role ${this.config.roleArn} for region ${this.config.region ?? 'undefined'}"`,
+      ],
+    };
+  }
+
+  public toCodeCatalyst(): CodeCatalystStepConfig {
+    //FIXME use CC environments here
+    return {
+      commands: [],
+      env: {},
+      needs: [],
     };
   }
 

--- a/src/steps/registries.ts
+++ b/src/steps/registries.ts
@@ -1,6 +1,8 @@
 import { Project } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
-import { GithubStepConfig, PipelineStep } from './step';
+import { AwsAssumeRoleStep } from './aws-assume-role.step';
+import { SetEnvStep } from './set-env.step';
+import { GithubStepConfig, PipelineStep, StepSequence } from './step';
 
 export interface GithubPackagesLoginStepOptions {
   /**
@@ -27,4 +29,24 @@ export class GithubPackagesLoginStep extends PipelineStep {
       permissions: { packages: this.options.write ? JobPermission.WRITE : JobPermission.READ },
     };
   }
+}
+
+export interface CodeArtifactLoginStepOptions {
+  readonly ownerAccount: string;
+  readonly region: string;
+  readonly domainName: string;
+  readonly role: string;
+}
+
+export class CodeArtifactLoginStep extends StepSequence {
+  constructor(project: Project, protected options: CodeArtifactLoginStepOptions) {
+    super(project, [
+      new AwsAssumeRoleStep(project, { roleArn: options.role, sessionName: 'CodeArtifact' }),
+      new SetEnvStep(project, {
+        name: 'CODEARTIFACT_AUTH_TOKEN',
+        command: `aws codeartifact get-authorization-token --domain ${options.domainName} --region ${options.region} --domain-owner ${options.ownerAccount} --query authorizationToken --output text`,
+      }),
+    ]);
+  }
+
 }

--- a/src/steps/set-env.step.ts
+++ b/src/steps/set-env.step.ts
@@ -1,0 +1,49 @@
+import { Project } from 'projen';
+import { BashStepConfig, CodeCatalystStepConfig, GithubStepConfig, GitlabStepConfig, PipelineStep } from './step';
+
+export interface SetEnvStepOptions {
+  readonly name: string;
+  readonly command: string;
+}
+
+export class SetEnvStep extends PipelineStep {
+  constructor(project: Project, protected options: SetEnvStepOptions) {
+    super(project);
+  }
+
+  public toBash(): BashStepConfig {
+    return {
+      commands: [`export ${this.options.name}=$(${this.options.command})`],
+    };
+  }
+
+  public toCodeCatalyst(): CodeCatalystStepConfig {
+    return {
+      env: {},
+      needs: [],
+      commands: [`export ${this.options.name}=$(${this.options.command})`],
+    };
+  }
+
+  public toGitlab(): GitlabStepConfig {
+    return {
+      env: {},
+      needs: [],
+      extensions: [],
+      commands: [`export ${this.options.name}=$(${this.options.command})`],
+    };
+  }
+
+  public toGithub(): GithubStepConfig {
+    return {
+      env: {},
+      needs: [],
+      permissions: {},
+      steps: [
+        {
+          run: `echo "${this.options.name}=$(${this.options.command})" >> $GITHUB_ENV`,
+        },
+      ],
+    };
+  }
+}

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -118,24 +118,21 @@ exports[`Bash snapshot 2`] = `
 
 Synthesize your CDK project:
 \`\`\`bash
-
 npx projen install:ci
-
 npx projen build
-
 \`\`\`
 
 Publish all your CDK assets like Lambda function code and container images:
 \`\`\`bash
-
 npx projen install:ci
+echo "Login to AWS using role undefined for region undefined"
 npx projen publish:assets
 \`\`\`
 
 If you want to store your cloud assembly and assets for future use or compliance reasons, use:
 \`\`\`bash
-
 npx projen install:ci
+echo "Login to AWS using role undefined for region undefined"
 npx projen publish:assets
 npx projen bump
 npx projen release:push-assembly
@@ -147,15 +144,19 @@ For every stage some scripts are generated for diff and deploy
 
 Stage: dev
 \`\`\`bash
+echo "Login to AWS using role undefined for region eu-central-1"
 npx projen diff:dev
 
+echo "Login to AWS using role undefined for region eu-central-1"
 npx projen deploy:dev
 \`\`\`
 
 Stage: prod
 \`\`\`bash
+echo "Login to AWS using role undefined for region eu-central-1"
 npx projen diff:prod
 
+echo "Login to AWS using role undefined for region eu-central-1"
 npx projen deploy:prod
 \`\`\`
 

--- a/test/__snapshots__/codecatalyst.test.ts.snap
+++ b/test/__snapshots__/codecatalyst.test.ts.snap
@@ -38,6 +38,7 @@ Actions:
         Enabled: false
     Configuration:
       Steps:
+        - Run: npx projen install:ci
         - Run: npx projen publish:assets
     DependsOn:
       - SynthCDKApplication

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -15,20 +15,20 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -50,12 +50,6 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: publishRole
-          role-session-name: GitHubAction
-          aws-region: us-east-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
@@ -83,25 +77,25 @@ jobs:
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: devRole
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: devRole
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:my-dev
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -179,22 +173,22 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
+      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
+      - run: mv ./node_modules/@assembly/testapp cdk.out
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: prodRole
           role-session-name: GitHubAction
           aws-region: eu-central-1
-      - run: npx projen install:ci
-      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
-      - run: mv ./node_modules/@assembly/testapp cdk.out
       - run: npx projen deploy:prod
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -628,20 +622,20 @@ jobs:
     needs: []
     runs-on: custom-runner
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -663,18 +657,18 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: publishRole
-          role-session-name: GitHubAction
-          aws-region: us-east-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: publishRole
+          role-session-name: GitHubAction
+          aws-region: us-east-1
       - run: npx projen publish:assets
 "
 `;
@@ -694,20 +688,20 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -729,18 +723,18 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: publishRole
-          role-session-name: GitHubAction
-          aws-region: us-east-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: publishRole
+          role-session-name: GitHubAction
+          aws-region: us-east-1
       - run: npx projen publish:assets
       - run: npx projen bump
       - run: npx projen release:push-assembly
@@ -749,26 +743,26 @@ jobs:
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     environment: my-dev
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: devRole
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: devRole
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:my-dev
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -780,25 +774,26 @@ jobs:
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     environment: independent
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: independentRole
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:independent
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -824,23 +819,23 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     environment: prod
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
+      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
+      - run: mv ./node_modules/@assembly/testapp cdk.out
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: prodRole
           role-session-name: GitHubAction
           aws-region: eu-central-1
-      - run: npx projen install:ci
-      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
-      - run: mv ./node_modules/@assembly/testapp cdk.out
       - run: npx projen deploy:prod
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -865,20 +860,20 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -900,43 +895,45 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-assembly
+          path: cdk.out/
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: publishRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: cloud-assembly
-          path: cdk.out/
-      - run: npx projen install:ci
       - run: npx projen publish:assets
   deploy-independent2:
     name: Deploy stage independent2 to AWS
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
+      FOO: bar
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:independent2
+      - run: echo Post Deploy
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
         with:
@@ -957,23 +954,35 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
       FOO: bar
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: synthRole
+          role-session-name: GitHubAction
+          aws-region: us-east-1
+      - run: npx projen build
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: deployRole
           role-session-name: GitHubAction
           aws-region: eu-central-1
-      - run: npx projen install:ci
-      - run: npx projen build
       - run: npx projen diff:independent1
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: deployRole
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:independent1
       - run: echo Post Deploy
       - name: Upload Artifact
@@ -1008,22 +1017,22 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       packages: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: echo "GITHUB_TOKEN=\${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: echo "GITHUB_TOKEN=\${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -1046,12 +1055,6 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: publishRole
-          role-session-name: GitHubAction
-          aws-region: us-east-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
@@ -1059,6 +1062,12 @@ jobs:
           path: cdk.out/
       - run: echo "GITHUB_TOKEN=\${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: publishRole
+          role-session-name: GitHubAction
+          aws-region: us-east-1
       - run: npx projen publish:assets
       - run: npx projen bump
       - run: npx projen release:push-assembly
@@ -1081,23 +1090,23 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       packages: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: echo "GITHUB_TOKEN=\${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - run: npx projen install:ci
+      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
+      - run: mv ./node_modules/@assembly/testapp cdk.out
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-session-name: GitHubAction
           aws-region: eu-central-1
-      - run: echo "GITHUB_TOKEN=\${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - run: npx projen install:ci
-      - run: yarn add @assembly/testapp@\${{github.event.inputs.version}}
-      - run: mv ./node_modules/@assembly/testapp cdk.out
       - run: npx projen deploy:prod
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -1122,20 +1131,20 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -1157,43 +1166,43 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-assembly
+          path: cdk.out/
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: publishRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: cloud-assembly
-          path: cdk.out/
-      - run: npx projen install:ci
       - run: npx projen publish:assets
   deploy-dev:
     name: Deploy stage dev to AWS
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: devRole
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
           name: cloud-assembly
           path: cdk.out/
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: devRole
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:dev
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -1495,22 +1504,22 @@ jobs:
     needs: []
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
       FOO: bar
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: echo Login
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: synthRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - run: echo Login
-      - run: npx projen install:ci
       - run: npx projen build
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6
@@ -1533,38 +1542,33 @@ jobs:
         with:
           fetch-depth: 0
       - run: git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cloud-assembly
+          path: cdk.out/
+      - run: echo Login
+      - run: npx projen install:ci
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: publishRole
           role-session-name: GitHubAction
           aws-region: us-east-1
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: cloud-assembly
-          path: cdk.out/
-      - run: echo Login
-      - run: npx projen install:ci
       - run: npx projen publish:assets
   deploy-prod:
     name: Deploy stage prod to AWS
     needs: assetUpload
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     env:
       CI: "true"
       FOO: bar
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-session-name: GitHubAction
-          aws-region: eu-central-1
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
@@ -1572,6 +1576,11 @@ jobs:
           path: cdk.out/
       - run: echo Login
       - run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-session-name: GitHubAction
+          aws-region: eu-central-1
       - run: npx projen deploy:prod
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.6

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -56,8 +56,8 @@ synth:
   needs: []
   stage: synth
   script:
-    - "awslogin synthRole "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
   variables: {}
 publish_assets:
@@ -68,7 +68,6 @@ publish_assets:
     - job: synth
       artifacts: true
   script:
-    - "awslogin publishRole "
     - npx projen install:ci
     - "awslogin publishRole "
     - npx projen publish:assets:dev
@@ -87,10 +86,11 @@ diff-dev:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen diff:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-dev:
   extends:
     - .aws_base
@@ -105,10 +105,11 @@ deploy-dev:
     - job: publish_assets
     - job: diff-dev
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen deploy:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 diff-prod:
   extends:
     - .aws_base
@@ -121,10 +122,11 @@ diff-prod:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen diff:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-prod:
   extends:
     - .aws_base
@@ -140,10 +142,11 @@ deploy-prod:
     - job: publish_assets
     - job: diff-prod
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen deploy:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 "
 `;
 
@@ -310,8 +313,8 @@ synth:
   needs: []
   stage: synth
   script:
-    - "awslogin synthRole "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
   variables: {}
 publish_assets:
@@ -322,8 +325,8 @@ publish_assets:
     - job: synth
       artifacts: true
   script:
-    - "awslogin publishRole "
     - npx projen install:ci
+    - "awslogin publishRole "
     - npx projen publish:assets
   variables: {}
 deploy-independent1:
@@ -334,10 +337,12 @@ deploy-independent1:
   when: manual
   needs: []
   script:
-    - "awslogin deployRole "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
+    - "awslogin deployRole "
     - npx projen diff:independent1
+    - "awslogin deployRole "
     - npx projen deploy:independent1
     - echo Post Deploy
   variables:
@@ -353,10 +358,12 @@ deploy-independent2:
       - main
   needs: []
   script:
-    - "awslogin undefined "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
+    - "awslogin deployRole "
     - npx projen diff:independent2
+    - "awslogin deployRole "
     - npx projen deploy:independent2
     - echo Post Deploy
   variables:
@@ -422,9 +429,9 @@ synth:
   needs: []
   stage: synth
   script:
-    - "awslogin synthRole "
     - echo Login
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
   variables:
     FOO: bar
@@ -436,9 +443,9 @@ publish_assets:
     - job: synth
       artifacts: true
   script:
-    - "awslogin publishRole "
     - echo Login
     - npx projen install:ci
+    - "awslogin publishRole "
     - npx projen publish:assets
   variables:
     FOO: bar
@@ -454,12 +461,13 @@ diff-prod:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin defaultRole "
     - echo Login
     - npx projen install:ci
+    - "awslogin defaultRole "
     - npx projen diff:prod
   variables:
     FOO: bar
+    AWS_REGION: eu-central-1
 deploy-prod:
   extends:
     - .aws_base
@@ -474,12 +482,13 @@ deploy-prod:
     - job: publish_assets
     - job: diff-prod
   script:
-    - "awslogin defaultRole "
     - echo Login
     - npx projen install:ci
+    - "awslogin defaultRole "
     - npx projen deploy:prod
   variables:
     FOO: bar
+    AWS_REGION: eu-central-1
 "
 `;
 
@@ -541,8 +550,8 @@ synth:
   tags:
     - defaultTag
   script:
-    - "awslogin synthRole "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
   variables: {}
 publish_assets:
@@ -555,8 +564,8 @@ publish_assets:
     - job: synth
       artifacts: true
   script:
-    - "awslogin publishRole "
     - npx projen install:ci
+    - "awslogin publishRole "
     - npx projen publish:assets
   variables: {}
 diff-dev:
@@ -573,10 +582,11 @@ diff-dev:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen diff:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-dev:
   extends:
     - .aws_base
@@ -593,10 +603,11 @@ deploy-dev:
     - job: publish_assets
     - job: diff-dev
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen deploy:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 diff-prod:
   extends:
     - .aws_base
@@ -611,10 +622,11 @@ diff-prod:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen diff:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-prod:
   extends:
     - .aws_base
@@ -632,10 +644,11 @@ deploy-prod:
     - job: publish_assets
     - job: diff-prod
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen deploy:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 "
 `;
 
@@ -697,8 +710,8 @@ synth:
   tags:
     - synthTag
   script:
-    - "awslogin synthRole "
     - npx projen install:ci
+    - "awslogin synthRole "
     - npx projen build
   variables: {}
 publish_assets:
@@ -711,8 +724,8 @@ publish_assets:
     - job: synth
       artifacts: true
   script:
-    - "awslogin publishRole "
     - npx projen install:ci
+    - "awslogin publishRole "
     - npx projen publish:assets
   variables: {}
 diff-dev:
@@ -729,10 +742,11 @@ diff-dev:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen diff:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-dev:
   extends:
     - .aws_base
@@ -749,10 +763,11 @@ deploy-dev:
     - job: publish_assets
     - job: diff-dev
   script:
-    - "awslogin devRole "
     - npx projen install:ci
+    - "awslogin devRole "
     - npx projen deploy:dev
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 diff-prod:
   extends:
     - .aws_base
@@ -767,10 +782,11 @@ diff-prod:
       artifacts: true
     - job: publish_assets
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen diff:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 deploy-prod:
   extends:
     - .aws_base
@@ -788,9 +804,10 @@ deploy-prod:
     - job: publish_assets
     - job: diff-prod
   script:
-    - "awslogin prodRole "
     - npx projen install:ci
+    - "awslogin prodRole "
     - npx projen deploy:prod
-  variables: {}
+  variables:
+    AWS_REGION: eu-central-1
 "
 `;

--- a/test/__snapshots__/step.test.ts.snap
+++ b/test/__snapshots__/step.test.ts.snap
@@ -35,3 +35,113 @@ exports[`SimpleCommandStep works correctly 3`] = `
   "needs": [],
 }
 `;
+
+exports[`StepSequence not sharing internal state 1`] = `
+{
+  "commands": [
+    "echo "Hello World"",
+    "echo 42",
+    "npx projen dummy",
+  ],
+}
+`;
+
+exports[`StepSequence not sharing internal state 2`] = `
+{
+  "commands": [
+    "echo "Hello World"",
+    "echo 42",
+    "npx projen dummy",
+  ],
+}
+`;
+
+exports[`StepSequence works correctly 1`] = `
+{
+  "commands": [
+    "echo "Login to AWS using role role for region undefined"",
+    "export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain domain --region eu-central-1 --domain-owner domainOwner --query authorizationToken --output text)",
+    "echo "Hello World"",
+    "echo 42",
+    "echo "Login to AWS using role roleArn for region undefined"",
+    "echo "Hello World"",
+    "echo 42",
+  ],
+}
+`;
+
+exports[`StepSequence works correctly 2`] = `
+{
+  "env": {},
+  "needs": [],
+  "permissions": {
+    "idToken": "write",
+  },
+  "steps": [
+    {
+      "name": "AWS Credentials",
+      "uses": "aws-actions/configure-aws-credentials@v4",
+      "with": {
+        "aws-region": "us-east-1",
+        "role-session-name": "CodeArtifact",
+        "role-to-assume": "role",
+      },
+    },
+    {
+      "run": "echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain domain --region eu-central-1 --domain-owner domainOwner --query authorizationToken --output text)" >> $GITHUB_ENV",
+    },
+    {
+      "run": "echo "Hello World"",
+    },
+    {
+      "run": "echo 42",
+    },
+    {
+      "name": "AWS Credentials",
+      "uses": "aws-actions/configure-aws-credentials@v4",
+      "with": {
+        "aws-region": "us-east-1",
+        "role-session-name": "GitHubAction",
+        "role-to-assume": "roleArn",
+      },
+    },
+    {
+      "run": "echo "Hello World"",
+    },
+    {
+      "run": "echo 42",
+    },
+  ],
+}
+`;
+
+exports[`StepSequence works correctly 3`] = `
+{
+  "commands": [
+    "awslogin role CodeArtifact",
+    "export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain domain --region eu-central-1 --domain-owner domainOwner --query authorizationToken --output text)",
+    "echo "Hello World"",
+    "echo 42",
+    "awslogin roleArn ",
+    "echo "Hello World"",
+    "echo 42",
+  ],
+  "env": {},
+  "extensions": [],
+  "needs": [],
+}
+`;
+
+exports[`StepSequence works correctly 4`] = `
+{
+  "commands": [
+    "export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain domain --region eu-central-1 --domain-owner domainOwner --query authorizationToken --output text)",
+    "echo "Hello World"",
+    "echo 42",
+    "echo "Hello World"",
+    "echo 42",
+  ],
+  "env": {},
+  "needs": [],
+}
+`;

--- a/test/bash.test.ts
+++ b/test/bash.test.ts
@@ -10,6 +10,7 @@ test('Bash snapshot', () => {
   });
 
   new BashCDKPipeline(p, {
+    iamRoleArns: {},
     pkgNamespace: '@assembly',
     personalStage: {
       env: {

--- a/test/codecatalyst.test.ts
+++ b/test/codecatalyst.test.ts
@@ -36,7 +36,6 @@ test('CodeCatalyst snapshot', () => {
   });
 
   const snapshot = synthSnapshot(p);
-  console.log(snapshot);
   expect(snapshot['.codecatalyst/workflows/deploy.yaml']).toMatchSnapshot();
   expect(snapshot['package.json']).toMatchSnapshot();
 });

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -60,6 +60,7 @@ test('Github snapshot with environment', () => {
       deployment: {
         'my-dev': 'devRole',
         'prod': 'prodRole',
+        'independent': 'independentRole',
       },
     },
     useGithubEnvironments: true,

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -203,6 +203,7 @@ test('Gitlab snapshot with independent stage', () => {
       assetPublishing: 'publishRole',
       deployment: {
         independent1: 'deployRole',
+        independent2: 'deployRole',
       },
     },
     pkgNamespace: '@assembly',

--- a/test/step.test.ts
+++ b/test/step.test.ts
@@ -1,5 +1,5 @@
 import { Project } from 'projen';
-import { SimpleCommandStep } from '../src';
+import { AwsAssumeRoleStep, CodeArtifactLoginStep, ProjenScriptStep, SimpleCommandStep, StepSequence } from '../src';
 
 /**
  * Tests the functionality of the SimpleCommandStep class.
@@ -25,4 +25,43 @@ test('SimpleCommandStep works correctly', () => {
   // Test that the GitLab CI configuration matches the expected snapshot.
   // This verifies that the toGitlab method outputs the correct configuration for GitLab pipelines.
   expect(step.toGitlab()).toMatchSnapshot();
+});
+
+// test StepSequence
+test('StepSequence works correctly', () => {
+  const project = new Project({ name: 'test-project' });
+
+  const sequence = new StepSequence(project, [
+    new CodeArtifactLoginStep(project, {
+      domainName: 'domain',
+      ownerAccount: 'domainOwner',
+      region: 'eu-central-1',
+      role: 'role',
+    }),
+    new SimpleCommandStep(project, ['echo "Hello World"', 'echo 42']),
+    new AwsAssumeRoleStep(project, { roleArn: 'roleArn' }),
+    new SimpleCommandStep(project, ['echo "Hello World"', 'echo 42']),
+  ]);
+
+  expect(sequence.toBash()).toMatchSnapshot();
+  expect(sequence.toGithub()).toMatchSnapshot();
+  expect(sequence.toGitlab()).toMatchSnapshot();
+  expect(sequence.toCodeCatalyst()).toMatchSnapshot();
+});
+
+test('StepSequence not sharing internal state', () => {
+  const project = new Project({ name: 'test-project' });
+
+  const preSteps = [
+    new SimpleCommandStep(project, ['echo "Hello World"', 'echo 42']),
+  ];
+
+  const sequence = new StepSequence(project, preSteps);
+  sequence.addSteps(new ProjenScriptStep(project, 'dummy'));
+
+  const sequence2 = new StepSequence(project, preSteps);
+  sequence2.addSteps(new ProjenScriptStep(project, 'dummy'));
+
+  expect(sequence.toBash()).toMatchSnapshot();
+  expect(sequence2.toBash()).toMatchSnapshot();
 });


### PR DESCRIPTION
Enhanced the CDK pipeline infrastructure to support dynamic IAM role assignment and introduced new pipeline step utilities. Changes include:

- Introduced `IamRoleConfig` for configuring IAM roles used at different stages of the pipeline.
- Added `AwsAssumeRoleStep`, `ProjenScriptStep`, `SimpleCommandStep`, `SetEnvStep`, and `StepSequence` classes to handle various step functionalities.
- Replaced hardcoded command renderings with dynamic step generation methods: `provideInstallStep`, `provideSynthStep`, `provideAssetUploadStep`, `provideAssemblyUploadStep`, `provideDeployStep`, and `provideDiffStep`.
- Updated all pipelines (`BashCDKPipeline`, `CodeCatalystCDKPipeline`, `GithubCDKPipeline`, `GitlabCDKPipeline`) to utilize the new step methods.

Fixes #118 , #117