### PR TITLE
feat(github): add concurrency settings to pipeline jobs

### DIFF
--- a/src/awscdk/github.ts
+++ b/src/awscdk/github.ts
@@ -239,6 +239,10 @@ export class GithubCDKPipeline extends CDKPipeline {
         ...this.options.useGithubEnvironments && {
           environment: stage.name,
         },
+        concurrency: {
+          group: `deploy-${stage.name}`,
+          cancelInProgress: false,
+        },
         env: {
           CI: 'true',
           ...steps.reduce((acc, step) => ({ ...acc, ...step.env }), {}),
@@ -285,6 +289,10 @@ export class GithubCDKPipeline extends CDKPipeline {
       name: `Deploy stage ${stage.name} to AWS`,
       ...this.options.useGithubEnvironments && {
         environment: stage.name,
+      },
+      concurrency: {
+        group: `deploy-${stage.name}`,
+        cancelInProgress: false,
       },
       needs: ['assetUpload', ...steps.flatMap(s => s.needs), ...jobDependencies],
       runsOn: this.options.runnerTags ?? DEFAULT_RUNNER_TAGS,
@@ -339,6 +347,10 @@ export class GithubCDKPipeline extends CDKPipeline {
         name: `Release stage ${stage.name} to AWS`,
         needs: steps.flatMap(s => s.needs),
         runsOn: this.options.runnerTags ?? DEFAULT_RUNNER_TAGS,
+        concurrency: {
+          group: `deploy-${stage.name}`,
+          cancelInProgress: false,
+        },
         env: {
           CI: 'true',
           ...steps.reduce((acc, step) => ({ ...acc, ...step.env }), {}),

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -85,6 +85,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-my-dev
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -184,6 +187,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-prod
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -857,6 +863,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-independent2
+      cancelInProgress: false
     env:
       CI: "true"
       TEST: me
@@ -901,6 +910,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-independent1
+      cancelInProgress: false
     env:
       CI: "true"
       TEST: me
@@ -1071,6 +1083,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-stage1
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -1106,6 +1121,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-stage2
+      cancelInProgress: false
     env:
       CI: "true"
       TEST: me
@@ -1272,6 +1290,9 @@ jobs:
       contents: read
       id-token: write
     environment: my-dev
+    concurrency:
+      group: deploy-my-dev
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -1306,6 +1327,9 @@ jobs:
       contents: read
       id-token: write
     environment: independent
+    concurrency:
+      group: deploy-independent
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -1354,6 +1378,9 @@ jobs:
       contents: read
       id-token: write
     environment: prod
+    concurrency:
+      group: deploy-prod
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -1456,6 +1483,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-independent2
+      cancelInProgress: false
     env:
       CI: "true"
       FOO: bar
@@ -1500,6 +1530,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-independent1
+      cancelInProgress: false
     env:
       CI: "true"
       FOO: bar
@@ -1646,6 +1679,9 @@ jobs:
       contents: read
       packages: read
       id-token: write
+    concurrency:
+      group: deploy-prod
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -1748,6 +1784,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-dev
+      cancelInProgress: false
     env:
       CI: "true"
     steps:
@@ -2142,6 +2181,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    concurrency:
+      group: deploy-prod
+      cancelInProgress: false
     env:
       CI: "true"
       FOO: bar


### PR DESCRIPTION
This update introduces concurrency settings for jobs in the `GithubCDKPipeline` class, allowing for better control over deployment processes. Each job now includes a `concurrency` property with a unique group identifier based on the stage name, ensuring that deployments are managed effectively without overlapping. Corresponding updates have been made to the test snapshots to reflect these changes.

Fixes #128