### PR TITLE
feat(pipelines): update pkgNamespace to be optional and enhance validation

### DIFF
--- a/API.md
+++ b/API.md
@@ -982,13 +982,13 @@ const bashCDKPipelineOptions: BashCDKPipelineOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
-| <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.deploySubStacks">deploySubStacks</a></code> | <code>boolean</code> | If set to true all CDK actions will also include <stackName>/* to deploy/diff/destroy sub stacks of the main stack. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.featureStages">featureStages</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for feature stages. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.independentStages">independentStages</a></code> | <code><a href="#projen-pipelines.IndependentStage">IndependentStage</a>[]</code> | This specifies details for independent stages. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.personalStage">personalStage</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for a personal stage. |
+| <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.postSynthCommands">postSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.postSynthSteps">postSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.BashCDKPipelineOptions.property.preInstallCommands">preInstallCommands</a></code> | <code>string[]</code> | *No description.* |
@@ -1008,21 +1008,6 @@ public readonly iamRoleArns: IamRoleConfig;
 - *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
 
 IAM config.
-
----
-
-##### `pkgNamespace`<sup>Required</sup> <a name="pkgNamespace" id="projen-pipelines.BashCDKPipelineOptions.property.pkgNamespace"></a>
-
-```typescript
-public readonly pkgNamespace: string;
-```
-
-- *Type:* string
-
-This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
-
-A namespace helps group related resources together, providing
-better organization and ease of management.
 
 ---
 
@@ -1099,6 +1084,24 @@ public readonly personalStage: StageOptions;
 - *Type:* <a href="#projen-pipelines.StageOptions">StageOptions</a>
 
 This specifies details for a personal stage.
+
+---
+
+##### `pkgNamespace`<sup>Optional</sup> <a name="pkgNamespace" id="projen-pipelines.BashCDKPipelineOptions.property.pkgNamespace"></a>
+
+```typescript
+public readonly pkgNamespace: string;
+```
+
+- *Type:* string
+- *Default:* 
+
+This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
+
+A namespace helps group related resources together, providing
+better organization and ease of management.
+
+This is only needed if you need to version and upload the cloud assembly to a package repository.
 
 ---
 
@@ -1228,13 +1231,13 @@ const cDKPipelineOptions: CDKPipelineOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
-| <code><a href="#projen-pipelines.CDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.deploySubStacks">deploySubStacks</a></code> | <code>boolean</code> | If set to true all CDK actions will also include <stackName>/* to deploy/diff/destroy sub stacks of the main stack. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.featureStages">featureStages</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for feature stages. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.independentStages">independentStages</a></code> | <code><a href="#projen-pipelines.IndependentStage">IndependentStage</a>[]</code> | This specifies details for independent stages. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.personalStage">personalStage</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for a personal stage. |
+| <code><a href="#projen-pipelines.CDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.postSynthCommands">postSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.postSynthSteps">postSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.CDKPipelineOptions.property.preInstallCommands">preInstallCommands</a></code> | <code>string[]</code> | *No description.* |
@@ -1254,21 +1257,6 @@ public readonly iamRoleArns: IamRoleConfig;
 - *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
 
 IAM config.
-
----
-
-##### `pkgNamespace`<sup>Required</sup> <a name="pkgNamespace" id="projen-pipelines.CDKPipelineOptions.property.pkgNamespace"></a>
-
-```typescript
-public readonly pkgNamespace: string;
-```
-
-- *Type:* string
-
-This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
-
-A namespace helps group related resources together, providing
-better organization and ease of management.
 
 ---
 
@@ -1345,6 +1333,24 @@ public readonly personalStage: StageOptions;
 - *Type:* <a href="#projen-pipelines.StageOptions">StageOptions</a>
 
 This specifies details for a personal stage.
+
+---
+
+##### `pkgNamespace`<sup>Optional</sup> <a name="pkgNamespace" id="projen-pipelines.CDKPipelineOptions.property.pkgNamespace"></a>
+
+```typescript
+public readonly pkgNamespace: string;
+```
+
+- *Type:* string
+- *Default:* 
+
+This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
+
+A namespace helps group related resources together, providing
+better organization and ease of management.
+
+This is only needed if you need to version and upload the cloud assembly to a package repository.
 
 ---
 
@@ -1747,13 +1753,13 @@ const githubCDKPipelineOptions: GithubCDKPipelineOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
-| <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.deploySubStacks">deploySubStacks</a></code> | <code>boolean</code> | If set to true all CDK actions will also include <stackName>/* to deploy/diff/destroy sub stacks of the main stack. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.featureStages">featureStages</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for feature stages. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.independentStages">independentStages</a></code> | <code><a href="#projen-pipelines.IndependentStage">IndependentStage</a>[]</code> | This specifies details for independent stages. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.personalStage">personalStage</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for a personal stage. |
+| <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.postSynthCommands">postSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.postSynthSteps">postSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GithubCDKPipelineOptions.property.preInstallCommands">preInstallCommands</a></code> | <code>string[]</code> | *No description.* |
@@ -1776,21 +1782,6 @@ public readonly iamRoleArns: IamRoleConfig;
 - *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
 
 IAM config.
-
----
-
-##### `pkgNamespace`<sup>Required</sup> <a name="pkgNamespace" id="projen-pipelines.GithubCDKPipelineOptions.property.pkgNamespace"></a>
-
-```typescript
-public readonly pkgNamespace: string;
-```
-
-- *Type:* string
-
-This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
-
-A namespace helps group related resources together, providing
-better organization and ease of management.
 
 ---
 
@@ -1867,6 +1858,24 @@ public readonly personalStage: StageOptions;
 - *Type:* <a href="#projen-pipelines.StageOptions">StageOptions</a>
 
 This specifies details for a personal stage.
+
+---
+
+##### `pkgNamespace`<sup>Optional</sup> <a name="pkgNamespace" id="projen-pipelines.GithubCDKPipelineOptions.property.pkgNamespace"></a>
+
+```typescript
+public readonly pkgNamespace: string;
+```
+
+- *Type:* string
+- *Default:* 
+
+This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
+
+A namespace helps group related resources together, providing
+better organization and ease of management.
+
+This is only needed if you need to version and upload the cloud assembly to a package repository.
 
 ---
 
@@ -2104,13 +2113,13 @@ const gitlabCDKPipelineOptions: GitlabCDKPipelineOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.iamRoleArns">iamRoleArns</a></code> | <code><a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a></code> | IAM config. |
-| <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DeploymentStage">DeploymentStage</a>[]</code> | This field specifies a list of stages that should be deployed using a CI/CD pipeline. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.branchName">branchName</a></code> | <code>string</code> | the name of the branch to deploy from. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.deploySubStacks">deploySubStacks</a></code> | <code>boolean</code> | If set to true all CDK actions will also include <stackName>/* to deploy/diff/destroy sub stacks of the main stack. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.featureStages">featureStages</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for feature stages. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.independentStages">independentStages</a></code> | <code><a href="#projen-pipelines.IndependentStage">IndependentStage</a>[]</code> | This specifies details for independent stages. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.personalStage">personalStage</a></code> | <code><a href="#projen-pipelines.StageOptions">StageOptions</a></code> | This specifies details for a personal stage. |
+| <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.pkgNamespace">pkgNamespace</a></code> | <code>string</code> | This field determines the NPM namespace to be used when packaging CDK cloud assemblies. |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.postSynthCommands">postSynthCommands</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.postSynthSteps">postSynthSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.GitlabCDKPipelineOptions.property.preInstallCommands">preInstallCommands</a></code> | <code>string[]</code> | *No description.* |
@@ -2132,21 +2141,6 @@ public readonly iamRoleArns: IamRoleConfig;
 - *Type:* <a href="#projen-pipelines.IamRoleConfig">IamRoleConfig</a>
 
 IAM config.
-
----
-
-##### `pkgNamespace`<sup>Required</sup> <a name="pkgNamespace" id="projen-pipelines.GitlabCDKPipelineOptions.property.pkgNamespace"></a>
-
-```typescript
-public readonly pkgNamespace: string;
-```
-
-- *Type:* string
-
-This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
-
-A namespace helps group related resources together, providing
-better organization and ease of management.
 
 ---
 
@@ -2223,6 +2217,24 @@ public readonly personalStage: StageOptions;
 - *Type:* <a href="#projen-pipelines.StageOptions">StageOptions</a>
 
 This specifies details for a personal stage.
+
+---
+
+##### `pkgNamespace`<sup>Optional</sup> <a name="pkgNamespace" id="projen-pipelines.GitlabCDKPipelineOptions.property.pkgNamespace"></a>
+
+```typescript
+public readonly pkgNamespace: string;
+```
+
+- *Type:* string
+- *Default:* 
+
+This field determines the NPM namespace to be used when packaging CDK cloud assemblies.
+
+A namespace helps group related resources together, providing
+better organization and ease of management.
+
+This is only needed if you need to version and upload the cloud assembly to a package repository.
 
 ---
 

--- a/src/awscdk/bash.ts
+++ b/src/awscdk/bash.ts
@@ -35,7 +35,9 @@ export class BashCDKPipeline extends CDKPipeline {
     readme.addLine('```bash');
     readme.addLine(`${this.provideInstallStep().toBash().commands.join('\n')}`);
     readme.addLine(`${this.provideAssetUploadStep().toBash().commands.join('\n')}`);
-    readme.addLine(`${this.provideAssemblyUploadStep().toBash().commands.join('\n')}`);
+    if (this.baseOptions.pkgNamespace) {
+      readme.addLine(`${this.provideAssemblyUploadStep().toBash().commands.join('\n')}`);
+    }
     readme.addLine('```');
     readme.addLine('');
     readme.addLine('## Deployment phase');

--- a/src/awscdk/github.ts
+++ b/src/awscdk/github.ts
@@ -79,7 +79,10 @@ export class GithubCDKPipeline extends CDKPipeline {
     });
 
     // Determine if versioned artifacts are necessary.
-    this.needsVersionedArtifacts = options.stages.find(s => s.manualApproval === true) !== undefined;;
+    this.needsVersionedArtifacts = options.stages.find(s => s.manualApproval === true) !== undefined;
+    if (this.needsVersionedArtifacts && !options.pkgNamespace) {
+      throw new Error('pkgNamespace is required when using versioned artifacts (e.g. manual approvals)');
+    }
     this.useGithubPackages = this.needsVersionedArtifacts && (options.useGithubPackagesForAssembly ?? false);
     this.minNodeVersion = app.minNodeVersion;
 

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -77,7 +77,6 @@ exports[`Bash snapshot 1`] = `
   },
   "scripts": {
     "build": "npx projen build",
-    "bump": "npx projen bump",
     "bundle": "npx projen bundle",
     "clobber": "npx projen clobber",
     "compile": "npx projen compile",
@@ -102,7 +101,6 @@ exports[`Bash snapshot 1`] = `
     "publish:assets": "npx projen publish:assets",
     "publish:assets:dev": "npx projen publish:assets:dev",
     "publish:assets:prod": "npx projen publish:assets:prod",
-    "release:push-assembly": "npx projen release:push-assembly",
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",
     "test": "npx projen test",
@@ -115,6 +113,70 @@ exports[`Bash snapshot 1`] = `
 `;
 
 exports[`Bash snapshot 2`] = `
+"# How to run your pipeline
+
+## Build phase
+
+Synthesize your CDK project:
+\`\`\`bash
+npx projen install:ci
+npx projen build
+\`\`\`
+
+Publish all your CDK assets like Lambda function code and container images:
+\`\`\`bash
+npx projen install:ci
+echo "Login to AWS using role undefined for region undefined"
+npx projen publish:assets
+\`\`\`
+
+If you want to store your cloud assembly and assets for future use or compliance reasons, use:
+\`\`\`bash
+npx projen install:ci
+echo "Login to AWS using role undefined for region undefined"
+npx projen publish:assets
+\`\`\`
+
+## Deployment phase
+
+For every stage some scripts are generated for diff and deploy
+
+Stage: dev
+\`\`\`bash
+echo "Login to AWS using role undefined for region eu-central-1"
+npx projen diff:dev
+
+echo "Login to AWS using role undefined for region eu-central-1"
+npx projen deploy:dev
+\`\`\`
+
+Stage: prod
+\`\`\`bash
+echo "Login to AWS using role undefined for region eu-central-1"
+npx projen diff:prod
+
+echo "Login to AWS using role undefined for region eu-central-1"
+npx projen deploy:prod
+\`\`\`
+
+The stage \`personal\` is meant to be deployed manually by the developer and also has a watch script for live updates.
+\`\`\`bash
+npx projen diff:personal
+npx projen deploy:personal
+npx projen destroy:personal
+npx projen watch:personal
+\`\`\`
+
+The stage \`feature\` is meant to be deployed for feature branches.
+\`\`\`bash
+npx projen diff:feature
+npx projen deploy:feature
+npx projen destroy:feature
+\`\`\`
+"
+`;
+
+exports[`Bash snapshot with pkgNamespace 1`] = `
 "# How to run your pipeline
 
 ## Build phase

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -1808,18 +1808,6 @@ exports[`Github snapshot with multi stack 2`] = `
         },
       ],
     },
-    "bump": {
-      "description": "Bumps version based on latest git tag",
-      "name": "bump",
-      "steps": [
-        {
-          "exec": "pipelines-release bump",
-        },
-        {
-          "exec": "git push --tags",
-        },
-      ],
-    },
     "bundle": {
       "description": "Prepare assets",
       "name": "bundle",
@@ -1967,22 +1955,6 @@ exports[`Github snapshot with multi stack 2`] = `
       "steps": [
         {
           "exec": "npx cdk-assets -p cdk.out/testapp-dev.assets.json publish",
-        },
-      ],
-    },
-    "release:push-assembly": {
-      "name": "release:push-assembly",
-      "steps": [
-        {
-          "exec": "pipelines-release create-manifest "cdk.out"  "@assembly"",
-        },
-        {
-          "cwd": "cdk.out",
-          "exec": "npm version --no-git-tag-version from-git",
-        },
-        {
-          "cwd": "cdk.out",
-          "exec": "npm publish",
         },
       ],
     },

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -227,7 +227,6 @@ exports[`Gitlab snapshot 2`] = `
   },
   "scripts": {
     "build": "npx projen build",
-    "bump": "npx projen bump",
     "bundle": "npx projen bundle",
     "clobber": "npx projen clobber",
     "compile": "npx projen compile",
@@ -248,7 +247,6 @@ exports[`Gitlab snapshot 2`] = `
     "publish:assets": "npx projen publish:assets",
     "publish:assets:dev": "npx projen publish:assets:dev",
     "publish:assets:prod": "npx projen publish:assets:prod",
-    "release:push-assembly": "npx projen release:push-assembly",
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",
     "test": "npx projen test",

--- a/test/bash.test.ts
+++ b/test/bash.test.ts
@@ -11,7 +11,6 @@ test('Bash snapshot', () => {
 
   new BashCDKPipeline(p, {
     iamRoleArns: {},
-    pkgNamespace: '@assembly',
     personalStage: {
       env: {
         account: '123456789012',
@@ -38,5 +37,41 @@ test('Bash snapshot', () => {
   expect(snapshot['.gitlab-ci.yml']).toBeUndefined();
   expect(snapshot['.github/workflows/deploy.yml']).toBeUndefined();
   expect(snapshot['package.json']).toMatchSnapshot();
+  expect(snapshot['pipeline.md']).toMatchSnapshot();
+});
+
+test('Bash snapshot with pkgNamespace', () => {
+  const p = new AwsCdkTypeScriptApp({
+    cdkVersion: '2.102.0',
+    defaultReleaseBranch: 'main',
+    name: 'testapp',
+  });
+
+  new BashCDKPipeline(p, {
+    iamRoleArns: {},
+    pkgNamespace: '@assembly',
+    personalStage: {
+      env: {
+        account: '123456789012',
+        region: 'eu-central-1',
+      },
+    },
+    stages: [{
+      name: 'dev',
+      env: {
+        account: '123456789012',
+        region: 'eu-central-1',
+      },
+    }, {
+      name: 'prod',
+      manualApproval: true,
+      env: {
+        account: '123456789012',
+        region: 'eu-central-1',
+      },
+    }],
+  });
+
+  const snapshot = synthSnapshot(p);
   expect(snapshot['pipeline.md']).toMatchSnapshot();
 });

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -109,7 +109,6 @@ test('Github snapshot with multi stack', () => {
         prod: 'prodRole',
       },
     },
-    pkgNamespace: '@assembly',
     deploySubStacks: true,
     stages: [{
       name: 'dev',
@@ -137,7 +136,6 @@ test('Github snapshot with custom runner', () => {
       synth: 'synthRole',
       assetPublishing: 'publishRole',
     },
-    pkgNamespace: '@assembly',
     deploySubStacks: true,
     stages: [],
     runnerTags: ['custom-runner'],
@@ -160,7 +158,6 @@ test('Github snapshot with custom node version', () => {
       synth: 'synthRole',
       assetPublishing: 'publishRole',
     },
-    pkgNamespace: '@assembly',
     stages: [],
   });
 
@@ -225,7 +222,6 @@ test('Github snapshot with preInstallStep', () => {
       assetPublishing: 'publishRole',
     },
     preInstallSteps: [new TestStep(p)],
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'prod',
       env: {
@@ -269,7 +265,6 @@ test('Github snapshot with independent stage', () => {
         independent1: 'deployRole',
       },
     },
-    pkgNamespace: '@assembly',
     stages: [],
     independentStages: [{
       name: 'independent1',
@@ -325,7 +320,6 @@ test('Github snapshot with empty prefix for stages', () => {
         stage2: 'deployRole2',
       },
     },
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'stage1',
       env: {
@@ -394,7 +388,6 @@ test('Github snapshot with empty prefix for independent stages', () => {
         independent1: 'deployRole',
       },
     },
-    pkgNamespace: '@assembly',
     stages: [],
     independentStages: [{
       name: 'independent1',
@@ -431,4 +424,28 @@ test('Github snapshot with empty prefix for independent stages', () => {
   expect(appTsSnapshot.includes('this, \'independent2\'')).toBeTruthy();
   expect(appTsSnapshot.includes('stackName: \'independent1\', stageName: \'independent1\'')).toBeTruthy();
   expect(appTsSnapshot.includes('stackName: \'independent2\', stageName: \'independent2\'')).toBeTruthy();
+});
+
+test('Github snapshot with manual approval and no pkgNamespace', () => {
+  const p = new AwsCdkTypeScriptApp({
+    cdkVersion: '2.132.0',
+    defaultReleaseBranch: 'main',
+    name: 'testapp',
+  });
+
+  expect(() => new GithubCDKPipeline(p, {
+    iamRoleArns: {
+      synth: 'synthRole',
+      assetPublishing: 'publishRole',
+    },
+    pkgNamespace: undefined,
+    stages: [{
+      name: 'prod',
+      manualApproval: true,
+      env: {
+        account: '123456789012',
+        region: 'eu-central-1',
+      },
+    }],
+  })).toThrow('pkgNamespace is required when using versioned artifacts (e.g. manual approvals)');
 });

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -21,7 +21,6 @@ test('Gitlab snapshot', () => {
         prod: 'prodRole',
       },
     },
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'dev',
       diffType: CdkDiffType.FAST,
@@ -73,7 +72,6 @@ test('Gitlab snapshot with runner tags', () => {
         prod: ['prodTag'],
       },
     },
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'dev',
       env: {
@@ -114,7 +112,6 @@ test('Gitlab snapshot with runner default tags', () => {
     runnerTags: {
       default: ['defaultTag'],
     },
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'dev',
       env: {
@@ -162,7 +159,6 @@ test('Gitlab snapshot with preInstallStep', () => {
       assetPublishing: 'publishRole',
     },
     preInstallSteps: [new TestStep(p)],
-    pkgNamespace: '@assembly',
     stages: [{
       name: 'prod',
       env: {
@@ -208,7 +204,6 @@ test('Gitlab snapshot with independent stage', () => {
         independent2: 'deployRole',
       },
     },
-    pkgNamespace: '@assembly',
     stages: [],
     independentStages: [{
       name: 'independent1',


### PR DESCRIPTION
The `pkgNamespace` property in the CDK pipeline options has been updated to be optional. This change allows for more flexible configurations, particularly when versioned artifacts are not required. Additionally, validation has been added to ensure that `pkgNamespace` is provided when manual approvals are used in the pipeline stages. Documentation has been updated to reflect these changes, and tests have been added to verify the new behavior.

Fixes #