### PR TITLE
feat(pipelines): add NpmSecretStep

### DIFF
--- a/API.md
+++ b/API.md
@@ -2944,6 +2944,8 @@ public readonly exportName: string;
 
 ### CodeArtifactLoginStepOptions <a name="CodeArtifactLoginStepOptions" id="projen-pipelines.CodeArtifactLoginStepOptions"></a>
 
+Options for the CodeArtifactLoginStep.
+
 #### Initializer <a name="Initializer" id="projen-pipelines.CodeArtifactLoginStepOptions.Initializer"></a>
 
 ```typescript
@@ -2960,6 +2962,7 @@ const codeArtifactLoginStepOptions: CodeArtifactLoginStepOptions = { ... }
 | <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.ownerAccount">ownerAccount</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.region">region</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.role">role</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.CodeArtifactLoginStepOptions.property.envVariableName">envVariableName</a></code> | <code>string</code> | The environment variable name to set. |
 
 ---
 
@@ -3000,6 +3003,19 @@ public readonly role: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `envVariableName`<sup>Optional</sup> <a name="envVariableName" id="projen-pipelines.CodeArtifactLoginStepOptions.property.envVariableName"></a>
+
+```typescript
+public readonly envVariableName: string;
+```
+
+- *Type:* string
+- *Default:* 'CODEARTIFACT_AUTH_TOKEN'
+
+The environment variable name to set.
 
 ---
 
@@ -5402,6 +5418,37 @@ public readonly watchable: boolean;
 
 ---
 
+### NpmSecretStepOptions <a name="NpmSecretStepOptions" id="projen-pipelines.NpmSecretStepOptions"></a>
+
+#### Initializer <a name="Initializer" id="projen-pipelines.NpmSecretStepOptions.Initializer"></a>
+
+```typescript
+import { NpmSecretStepOptions } from 'projen-pipelines'
+
+const npmSecretStepOptions: NpmSecretStepOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.NpmSecretStepOptions.property.secretName">secretName</a></code> | <code>string</code> | Name of the secret to set for the environment variable NPM_TOKEN. |
+
+---
+
+##### `secretName`<sup>Optional</sup> <a name="secretName" id="projen-pipelines.NpmSecretStepOptions.property.secretName"></a>
+
+```typescript
+public readonly secretName: string;
+```
+
+- *Type:* string
+- *Default:* 'NPM_TOKEN'
+
+Name of the secret to set for the environment variable NPM_TOKEN.
+
+---
+
 ### PackageJsonConfig <a name="PackageJsonConfig" id="projen-pipelines.PackageJsonConfig"></a>
 
 #### Initializer <a name="Initializer" id="projen-pipelines.PackageJsonConfig.Initializer"></a>
@@ -6046,6 +6093,11 @@ public readonly TYPE: string;
 
 ### CodeArtifactLoginStep <a name="CodeArtifactLoginStep" id="projen-pipelines.CodeArtifactLoginStep"></a>
 
+Step to login to CodeArtifact.
+
+The environment variable name can be configured to avoid conflicts with other environment variables.
+The default is CODEARTIFACT_AUTH_TOKEN.
+
 #### Initializers <a name="Initializers" id="projen-pipelines.CodeArtifactLoginStep.Initializer"></a>
 
 ```typescript
@@ -6416,6 +6468,10 @@ public prependSteps(steps: ...PipelineStep[]): void
 
 ### GithubPackagesLoginStep <a name="GithubPackagesLoginStep" id="projen-pipelines.GithubPackagesLoginStep"></a>
 
+Step to set the GITHUB_TOKEN environment variable from a secret.
+
+Only supported for GitHub as it is GitHub specific.
+
 #### Initializers <a name="Initializers" id="projen-pipelines.GithubPackagesLoginStep.Initializer"></a>
 
 ```typescript
@@ -6487,6 +6543,96 @@ Generates a configuration for a GitHub Actions step.
 Should be implemented by subclasses.
 
 ##### `toGitlab` <a name="toGitlab" id="projen-pipelines.GithubPackagesLoginStep.toGitlab"></a>
+
+```typescript
+public toGitlab(): GitlabStepConfig
+```
+
+Generates a configuration for a GitLab CI step.
+
+Should be implemented by subclasses.
+
+
+
+
+### NpmSecretStep <a name="NpmSecretStep" id="projen-pipelines.NpmSecretStep"></a>
+
+Step to set the NPM_TOKEN environment variable from a secret.
+
+Currently only supported and needed for GitHub.
+Gitlab sets the NPM_TOKEN environment variable automatically from the project's settings.
+
+#### Initializers <a name="Initializers" id="projen-pipelines.NpmSecretStep.Initializer"></a>
+
+```typescript
+import { NpmSecretStep } from 'projen-pipelines'
+
+new NpmSecretStep(project: Project, options: NpmSecretStepOptions)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen-pipelines.NpmSecretStep.Initializer.parameter.project">project</a></code> | <code>projen.Project</code> | - The projen project reference. |
+| <code><a href="#projen-pipelines.NpmSecretStep.Initializer.parameter.options">options</a></code> | <code><a href="#projen-pipelines.NpmSecretStepOptions">NpmSecretStepOptions</a></code> | *No description.* |
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen-pipelines.NpmSecretStep.Initializer.parameter.project"></a>
+
+- *Type:* projen.Project
+
+The projen project reference.
+
+---
+
+##### `options`<sup>Required</sup> <a name="options" id="projen-pipelines.NpmSecretStep.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#projen-pipelines.NpmSecretStepOptions">NpmSecretStepOptions</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen-pipelines.NpmSecretStep.toBash">toBash</a></code> | Generates a configuration for a bash script step. |
+| <code><a href="#projen-pipelines.NpmSecretStep.toCodeCatalyst">toCodeCatalyst</a></code> | Generates a configuration for a CodeCatalyst Actions step. |
+| <code><a href="#projen-pipelines.NpmSecretStep.toGithub">toGithub</a></code> | Generates a configuration for a GitHub Actions step. |
+| <code><a href="#projen-pipelines.NpmSecretStep.toGitlab">toGitlab</a></code> | Generates a configuration for a GitLab CI step. |
+
+---
+
+##### `toBash` <a name="toBash" id="projen-pipelines.NpmSecretStep.toBash"></a>
+
+```typescript
+public toBash(): BashStepConfig
+```
+
+Generates a configuration for a bash script step.
+
+Should be implemented by subclasses.
+
+##### `toCodeCatalyst` <a name="toCodeCatalyst" id="projen-pipelines.NpmSecretStep.toCodeCatalyst"></a>
+
+```typescript
+public toCodeCatalyst(): CodeCatalystStepConfig
+```
+
+Generates a configuration for a CodeCatalyst Actions step.
+
+Should be implemented by subclasses.
+
+##### `toGithub` <a name="toGithub" id="projen-pipelines.NpmSecretStep.toGithub"></a>
+
+```typescript
+public toGithub(): GithubStepConfig
+```
+
+Generates a configuration for a GitHub Actions step.
+
+Should be implemented by subclasses.
+
+##### `toGitlab` <a name="toGitlab" id="projen-pipelines.NpmSecretStep.toGitlab"></a>
 
 ```typescript
 public toGitlab(): GitlabStepConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -906,9 +906,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -953,14 +953,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3421,9 +3434,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5109,9 +5122,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5212,9 +5225,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5823,15 +5836,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -6174,9 +6188,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7184,9 +7198,9 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13903,9 +13917,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/steps/registries.ts
+++ b/src/steps/registries.ts
@@ -13,6 +13,11 @@ export interface GithubPackagesLoginStepOptions {
   readonly write?: boolean;
 }
 
+/**
+ * Step to set the GITHUB_TOKEN environment variable from a secret.
+ *
+ * Only supported for GitHub as it is GitHub specific.
+ */
 export class GithubPackagesLoginStep extends PipelineStep {
 
   constructor(project: Project, private options: GithubPackagesLoginStepOptions) {
@@ -31,19 +36,68 @@ export class GithubPackagesLoginStep extends PipelineStep {
   }
 }
 
+export interface NpmSecretStepOptions {
+  /**
+   * Name of the secret to set for the environment variable NPM_TOKEN.
+   *
+   * @default 'NPM_TOKEN'
+   */
+  readonly secretName?: string;
+}
+
+/**
+ * Step to set the NPM_TOKEN environment variable from a secret.
+ *
+ * Currently only supported and needed for GitHub.
+ * Gitlab sets the NPM_TOKEN environment variable automatically from the project's settings.
+ */
+export class NpmSecretStep extends PipelineStep {
+
+  constructor(project: Project, private options: NpmSecretStepOptions) {
+    super(project);
+  }
+
+  public toGithub(): GithubStepConfig {
+    return {
+      env: {},
+      needs: [],
+      steps: [{
+        run: `echo "NPM_TOKEN=\${{ secrets.${this.options.secretName ?? 'NPM_TOKEN'} }}" >> $GITHUB_ENV`,
+      }],
+      permissions: {},
+    };
+  }
+}
+
+/**
+ * Options for the CodeArtifactLoginStep.
+ */
 export interface CodeArtifactLoginStepOptions {
   readonly ownerAccount: string;
   readonly region: string;
   readonly domainName: string;
   readonly role: string;
+
+  /**
+   * The environment variable name to set.
+   *
+   * @default 'CODEARTIFACT_AUTH_TOKEN'
+   */
+  readonly envVariableName?: string;
 }
 
+/**
+ * Step to login to CodeArtifact.
+ *
+ * The environment variable name can be configured to avoid conflicts with other environment variables.
+ * The default is CODEARTIFACT_AUTH_TOKEN.
+ */
 export class CodeArtifactLoginStep extends StepSequence {
   constructor(project: Project, protected options: CodeArtifactLoginStepOptions) {
     super(project, [
       new AwsAssumeRoleStep(project, { roleArn: options.role, sessionName: 'CodeArtifact' }),
       new SetEnvStep(project, {
-        name: 'CODEARTIFACT_AUTH_TOKEN',
+        name: options.envVariableName ?? 'CODEARTIFACT_AUTH_TOKEN',
         command: `aws codeartifact get-authorization-token --domain ${options.domainName} --region ${options.region} --domain-owner ${options.ownerAccount} --query authorizationToken --output text`,
       }),
     ]);


### PR DESCRIPTION

This commit introduces the `NpmSecretStep` for setting the NPM_TOKEN environment variable from a secret, specifically for GitHub. It also enhances the `CodeArtifactLoginStep` by adding an optional `envVariableName` property to customize the environment variable name used for authentication. Documentation has been updated to reflect these changes, providing clearer guidance on the new features.