### PR TITLE
fix: Use Node.js built-in module imports (node: prefix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,9 +2593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2610,9 +2607,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2627,9 +2621,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2644,9 +2635,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2661,9 +2649,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2678,9 +2663,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2695,9 +2677,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2712,9 +2691,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -788,7 +788,7 @@ ${appCode}
 
     imports.push("import { CfnOutput } from 'aws-cdk-lib';");
     imports.push("import { StringParameter } from 'aws-cdk-lib/aws-ssm';");
-    imports.push("import * as fs from 'fs';");
+    imports.push("import * as fs from 'node:fs';");
 
     return imports.join('\n');
   }

--- a/src/drift/detect-drift.ts
+++ b/src/drift/detect-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 
 interface DriftDetectionOptions {
   region: string;

--- a/src/drift/github.ts
+++ b/src/drift/github.ts
@@ -126,7 +126,7 @@ export class GitHubDriftDetectionWorkflow extends DriftDetectionWorkflow {
 
   private generateIssueCreationScript(stage: DriftDetectionStageOptions): string {
     return `
-const fs = require('fs');
+const fs = require('node:fs');
 const resultsFile = '${this.namePrefix}drift-results-${stage.name}.json';
 
 if (!fs.existsSync(resultsFile)) {

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 // @ts-ignore
 import ctv from 'commit-and-tag-version';
 

--- a/src/versioning/setup.ts
+++ b/src/versioning/setup.ts
@@ -74,8 +74,8 @@ export class VersioningSetup {
     const strategyJson = JSON.stringify(this.config.strategy).replace(/"/g, '\\"');
 
     return `node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -312,7 +312,7 @@ exports[`Bash snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -960,8 +960,8 @@ exports[`Bash snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3015,7 +3015,7 @@ exports[`Github snapshot with jump roles 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -3663,8 +3663,8 @@ exports[`Github snapshot with jump roles 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');
@@ -5293,7 +5293,7 @@ exports[`Github snapshot with separate asset upload jobs 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -5941,8 +5941,8 @@ exports[`Github snapshot with separate asset upload jobs 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');
@@ -6275,7 +6275,7 @@ exports[`Github snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -6923,8 +6923,8 @@ exports[`Github snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -1395,7 +1395,7 @@ exports[`Gitlab snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -2043,8 +2043,8 @@ exports[`Gitlab snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');


### PR DESCRIPTION
Replace CommonJS and ES module imports of Node.js built-in modules (`fs`, `path`, `child_process`) with the standardized `node:` prefix format.

This change modernizes the codebase to use Node.js's official module naming convention for built-in modules, which is the recommended approach for Node.js 14.18.0+ and provides better clarity that these are built-in modules rather than third-party packages.

Changes made:
- Updated `src/drift/detect-drift.ts` to use `node:child_process` and `node:fs`
- Updated `src/release.ts` to use `node:fs` and `node:path`
- Updated `src/versioning/setup.ts` to use `node:fs` and `node:child_process` in generated code
- Updated `src/awscdk/base.ts` to use `node:fs` in generated CDK app code
- Updated `src/drift/github.ts` to use `node:fs` in generated script
- Updated test snapshots to reflect the new import format

Test Plan: Existing snapshot tests pass with updated expectations.

https://claude.ai/code/session_01NrBj4px2h5bomL3ztR6oMa