### PR TITLE
fix: auto-detect package manager in drift detection workflows

### DIFF
--- a/API.md
+++ b/API.md
@@ -2927,6 +2927,7 @@ const bashDriftDetectionWorkflowOptions: BashDriftDetectionWorkflowOptions = { .
 | <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DriftDetectionStageOptions">DriftDetectionStageOptions</a>[]</code> | Drift detection configurations for different environments. |
 | <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.name">name</a></code> | <code>string</code> | Name of the workflow. |
 | <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.pipelineName">pipelineName</a></code> | <code>string</code> | A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos. |
+| <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.preInstallSteps">preInstallSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command. |
 | <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.schedule">schedule</a></code> | <code>string</code> | Cron schedule for drift detection. |
 | <code><a href="#projen-pipelines.BashDriftDetectionWorkflowOptions.property.scriptPath">scriptPath</a></code> | <code>string</code> | Path to the output script. |
 
@@ -2967,6 +2968,23 @@ public readonly pipelineName: string;
 - *Default:* no prefix
 
 A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos.
+
+---
+
+##### `preInstallSteps`<sup>Optional</sup> <a name="preInstallSteps" id="projen-pipelines.BashDriftDetectionWorkflowOptions.property.preInstallSteps"></a>
+
+```typescript
+public readonly preInstallSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+- *Default:* no additional pre-install steps
+
+Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command.
+
+Note: Package manager setup (e.g., PnpmSetupStep for pnpm or CorepackSetupStep
+for Yarn Berry) is automatically detected from the project and always included.
+Use this option for any additional pre-install steps you need.
 
 ---
 
@@ -4242,6 +4260,7 @@ const driftDetectionWorkflowOptions: DriftDetectionWorkflowOptions = { ... }
 | <code><a href="#projen-pipelines.DriftDetectionWorkflowOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DriftDetectionStageOptions">DriftDetectionStageOptions</a>[]</code> | Drift detection configurations for different environments. |
 | <code><a href="#projen-pipelines.DriftDetectionWorkflowOptions.property.name">name</a></code> | <code>string</code> | Name of the workflow. |
 | <code><a href="#projen-pipelines.DriftDetectionWorkflowOptions.property.pipelineName">pipelineName</a></code> | <code>string</code> | A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos. |
+| <code><a href="#projen-pipelines.DriftDetectionWorkflowOptions.property.preInstallSteps">preInstallSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command. |
 | <code><a href="#projen-pipelines.DriftDetectionWorkflowOptions.property.schedule">schedule</a></code> | <code>string</code> | Cron schedule for drift detection. |
 
 ---
@@ -4281,6 +4300,23 @@ public readonly pipelineName: string;
 - *Default:* no prefix
 
 A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos.
+
+---
+
+##### `preInstallSteps`<sup>Optional</sup> <a name="preInstallSteps" id="projen-pipelines.DriftDetectionWorkflowOptions.property.preInstallSteps"></a>
+
+```typescript
+public readonly preInstallSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+- *Default:* no additional pre-install steps
+
+Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command.
+
+Note: Package manager setup (e.g., PnpmSetupStep for pnpm or CorepackSetupStep
+for Yarn Berry) is automatically detected from the project and always included.
+Use this option for any additional pre-install steps you need.
 
 ---
 
@@ -4852,6 +4888,7 @@ const gitHubDriftDetectionWorkflowOptions: GitHubDriftDetectionWorkflowOptions =
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DriftDetectionStageOptions">DriftDetectionStageOptions</a>[]</code> | Drift detection configurations for different environments. |
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.name">name</a></code> | <code>string</code> | Name of the workflow. |
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.pipelineName">pipelineName</a></code> | <code>string</code> | A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos. |
+| <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.preInstallSteps">preInstallSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command. |
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.schedule">schedule</a></code> | <code>string</code> | Cron schedule for drift detection. |
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.createIssues">createIssues</a></code> | <code>boolean</code> | Whether to create issues on drift detection. |
 | <code><a href="#projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.permissions">permissions</a></code> | <code>{[ key: string ]: string}</code> | Additional permissions for GitHub workflow. |
@@ -4893,6 +4930,23 @@ public readonly pipelineName: string;
 - *Default:* no prefix
 
 A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos.
+
+---
+
+##### `preInstallSteps`<sup>Optional</sup> <a name="preInstallSteps" id="projen-pipelines.GitHubDriftDetectionWorkflowOptions.property.preInstallSteps"></a>
+
+```typescript
+public readonly preInstallSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+- *Default:* no additional pre-install steps
+
+Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command.
+
+Note: Package manager setup (e.g., PnpmSetupStep for pnpm or CorepackSetupStep
+for Yarn Berry) is automatically detected from the project and always included.
+Use this option for any additional pre-install steps you need.
 
 ---
 
@@ -5555,6 +5609,7 @@ const gitLabDriftDetectionWorkflowOptions: GitLabDriftDetectionWorkflowOptions =
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.stages">stages</a></code> | <code><a href="#projen-pipelines.DriftDetectionStageOptions">DriftDetectionStageOptions</a>[]</code> | Drift detection configurations for different environments. |
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.name">name</a></code> | <code>string</code> | Name of the workflow. |
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.pipelineName">pipelineName</a></code> | <code>string</code> | A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos. |
+| <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.preInstallSteps">preInstallSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command. |
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.schedule">schedule</a></code> | <code>string</code> | Cron schedule for drift detection. |
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.image">image</a></code> | <code>string</code> | Docker image to use for drift detection. |
 | <code><a href="#projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.runnerTags">runnerTags</a></code> | <code>string[]</code> | GitLab runner tags. |
@@ -5596,6 +5651,23 @@ public readonly pipelineName: string;
 - *Default:* no prefix
 
 A unique name for this pipeline, used as a prefix for workflow files and artifact names to prevent collisions in monorepos.
+
+---
+
+##### `preInstallSteps`<sup>Optional</sup> <a name="preInstallSteps" id="projen-pipelines.GitLabDriftDetectionWorkflowOptions.property.preInstallSteps"></a>
+
+```typescript
+public readonly preInstallSteps: PipelineStep[];
+```
+
+- *Type:* <a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]
+- *Default:* no additional pre-install steps
+
+Additional steps to execute before installing dependencies. These steps are executed before the package manager setup and install command.
+
+Note: Package manager setup (e.g., PnpmSetupStep for pnpm or CorepackSetupStep
+for Yarn Berry) is automatically detected from the project and always included.
+Use this option for any additional pre-install steps you need.
 
 ---
 

--- a/src/drift/base.ts
+++ b/src/drift/base.ts
@@ -1,4 +1,6 @@
 import { Component, Project } from 'projen';
+import { NodePackageManager } from 'projen/lib/javascript';
+import { PipelineStep, PnpmSetupStep, CorepackSetupStep } from '../steps';
 
 export interface DriftDetectionStageOptions {
   /**
@@ -80,12 +82,25 @@ export interface DriftDetectionWorkflowOptions {
    * Drift detection configurations for different environments
    */
   readonly stages: DriftDetectionStageOptions[];
+
+  /**
+   * Additional steps to execute before installing dependencies.
+   * These steps are executed before the package manager setup and install command.
+   *
+   * Note: Package manager setup (e.g., PnpmSetupStep for pnpm or CorepackSetupStep
+   * for Yarn Berry) is automatically detected from the project and always included.
+   * Use this option for any additional pre-install steps you need.
+   *
+   * @default - no additional pre-install steps
+   */
+  readonly preInstallSteps?: PipelineStep[];
 }
 
 export abstract class DriftDetectionWorkflow extends Component {
   public readonly name: string;
   public readonly schedule: string;
   protected readonly stages: DriftDetectionStageOptions[];
+  protected readonly preInstallSteps: PipelineStep[];
 
   /** Prefix for workflow files and artifact names to prevent collisions in monorepos. */
   protected readonly namePrefix: string;
@@ -97,6 +112,34 @@ export abstract class DriftDetectionWorkflow extends Component {
     this.name = options.name ?? 'drift-detection';
     this.schedule = options.schedule ?? '0 0 * * *';
     this.stages = options.stages;
+    this.preInstallSteps = [
+      ...(options.preInstallSteps ?? []),
+      ...this.detectPackageManagerSteps(project),
+    ];
+  }
+
+  /**
+   * Detects the package manager from the project and returns appropriate setup steps.
+   * If the project is a NodeProject (has a `package` property), it inspects the
+   * packageManager to determine if pnpm or Yarn Berry setup is needed.
+   */
+  private detectPackageManagerSteps(project: Project): PipelineStep[] {
+    const pkg = (project as any).package;
+    if (!pkg || !pkg.packageManager) {
+      return [];
+    }
+
+    const steps: PipelineStep[] = [];
+
+    if (pkg.packageManager === NodePackageManager.PNPM) {
+      steps.push(new PnpmSetupStep(project, {
+        version: pkg.pnpmVersion,
+      }));
+    } else if (pkg.packageManager === NodePackageManager.YARN_BERRY) {
+      steps.push(new CorepackSetupStep(project));
+    }
+
+    return steps;
   }
 
 }

--- a/src/drift/bash.ts
+++ b/src/drift/bash.ts
@@ -51,6 +51,7 @@ export class BashDriftDetectionWorkflow extends DriftDetectionWorkflow {
       '# Install dependencies if not already installed',
       'if ! command -v ts-node &> /dev/null; then',
       '  echo "Installing dependencies..."',
+      ...this.preInstallSteps.flatMap(step => step.toBash().commands.map(cmd => `  ${cmd}`)),
       `  ${this.project.projenCommand} install:ci`,
       'fi',
       '',

--- a/src/drift/github.ts
+++ b/src/drift/github.ts
@@ -73,6 +73,7 @@ export class GitHubDriftDetectionWorkflow extends DriftDetectionWorkflow {
               'node-version': '20',
             },
           },
+          ...this.preInstallSteps.flatMap(step => step.toGithub().steps),
           {
             name: 'Install dependencies',
             run: `${this.project.projenCommand} install:ci`,

--- a/src/drift/gitlab.ts
+++ b/src/drift/gitlab.ts
@@ -48,6 +48,7 @@ export class GitLabDriftDetectionWorkflow extends DriftDetectionWorkflow {
         beforeScript: [
           'apt-get update && apt-get install -y python3 python3-pip',
           'pip3 install awscli',
+          ...this.preInstallSteps.flatMap(step => step.toGitlab().commands),
           `${this.project.projenCommand} install:ci`,
         ],
         artifacts: {

--- a/src/steps/package-manager-setup.step.ts
+++ b/src/steps/package-manager-setup.step.ts
@@ -38,6 +38,21 @@ export class PnpmSetupStep extends PipelineStep {
       }],
     };
   }
+
+  public toGitlab(): GitlabStepConfig {
+    return {
+      extensions: [],
+      commands: [`npm install -g pnpm@${this.options.version ?? '9'}`],
+      needs: [],
+      env: {},
+    };
+  }
+
+  public toBash(): BashStepConfig {
+    return {
+      commands: [`npm install -g pnpm@${this.options.version ?? '9'}`],
+    };
+  }
 }
 
 /**

--- a/test/drift/__snapshots__/drift-detection.test.ts.snap
+++ b/test/drift/__snapshots__/drift-detection.test.ts.snap
@@ -1,5 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BashDriftDetectionWorkflow should auto-detect pnpm and include pnpm install for NodeProject with pnpm 1`] = `
+"#!/bin/bash
+set -euo pipefail
+
+# Drift Detection Script
+
+# Parse command line arguments
+STAGE=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--stage STAGE_NAME]"
+      exit 1
+      ;;
+  esac
+done
+
+# Install dependencies if not already installed
+if ! command -v ts-node &> /dev/null; then
+  echo "Installing dependencies..."
+  npm install -g pnpm@9
+  pnpm exec projen install:ci
+fi
+
+# Function to run drift detection for a stage
+run_drift_detection() {
+  local stage_name=$1
+  local region=$2
+  local role_arn=$3
+  local stacks=$4
+  local fail_on_drift=$5
+  local error_handlers=$6
+  local env_vars=$7
+
+  echo "========================================"
+  echo "Running drift detection for stage: $stage_name"
+  echo "========================================"
+
+  # Set environment variables
+  export AWS_DEFAULT_REGION="$region"
+  export DRIFT_DETECTION_OUTPUT="drift-results-$stage_name.json"
+  eval "$env_vars"
+
+  # Assume role if provided
+  if [[ -n "$role_arn" ]]; then
+    echo "Assuming role: $role_arn"
+    CREDS=$(aws sts assume-role \\
+      --role-arn "$role_arn" \\
+      --role-session-name "drift-detection-$stage_name" \\
+      --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \\
+      --output text)
+    export AWS_ACCESS_KEY_ID=$(echo $CREDS | cut -d' ' -f1)
+    export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | cut -d' ' -f2)
+    export AWS_SESSION_TOKEN=$(echo $CREDS | cut -d' ' -f3)
+  fi
+
+  # Build command
+  local cmd="npx ts-node src/drift/detect-drift.ts --region $region"
+  
+  if [[ -n "$stacks" ]]; then
+    cmd="$cmd --stacks $stacks"
+  fi
+  
+  if [[ "$fail_on_drift" == "false" ]]; then
+    cmd="$cmd --no-fail-on-drift"
+  fi
+  
+  if [[ -n "$error_handlers" ]]; then
+    cmd="$cmd --error-handlers '$error_handlers'"
+  fi
+
+  # Run drift detection
+  echo "Running: $cmd"
+  eval "$cmd" || {
+    local exit_code=$?
+    echo "Drift detection failed with exit code: $exit_code"
+    if [[ "$fail_on_drift" == "true" ]]; then
+      return $exit_code
+    fi
+  }
+}
+
+# Stage configurations
+# Stage: production
+run_stage_production() {
+  export AWS_DEFAULT_REGION="us-east-1"
+  export DRIFT_DETECTION_OUTPUT="drift-results-production.json"
+  export AWS_REGION="us-east-1"
+  export STAGE_NAME="production"
+  detect-drift --region us-east-1
+}
+
+# Main execution
+FAILED_STAGES=()
+
+if [[ -n "$STAGE" ]]; then
+  # Run specific stage
+  case "$STAGE" in
+    production)
+      run_stage_production || FAILED_STAGES+=("production")
+      ;;
+    *)
+      echo "Unknown stage: $STAGE"
+      echo "Available stages:"
+      echo "  - production"
+      exit 1
+      ;;
+  esac
+else
+  # Run all stages
+  run_stage_production || FAILED_STAGES+=("production")
+fi
+
+# Summary
+echo ""
+echo "========================================"
+echo "DRIFT DETECTION COMPLETE"
+echo "========================================"
+
+if [[ \${#FAILED_STAGES[@]} -gt 0 ]]; then
+  echo "Failed stages:"
+  printf '  - %s\\n' "\${FAILED_STAGES[@]}"
+  exit 1
+else
+  echo "All stages completed successfully"
+fi"
+`;
+
 exports[`BashDriftDetectionWorkflow should create bash script 1`] = `
 "#!/bin/bash
 set -euo pipefail
@@ -130,6 +263,139 @@ else
   # Run all stages
   run_stage_production || FAILED_STAGES+=("production")
   run_stage_staging || FAILED_STAGES+=("staging")
+fi
+
+# Summary
+echo ""
+echo "========================================"
+echo "DRIFT DETECTION COMPLETE"
+echo "========================================"
+
+if [[ \${#FAILED_STAGES[@]} -gt 0 ]]; then
+  echo "Failed stages:"
+  printf '  - %s\\n' "\${FAILED_STAGES[@]}"
+  exit 1
+else
+  echo "All stages completed successfully"
+fi"
+`;
+
+exports[`BashDriftDetectionWorkflow should include corepack setup when preInstallSteps contains CorepackSetupStep 1`] = `
+"#!/bin/bash
+set -euo pipefail
+
+# Drift Detection Script
+
+# Parse command line arguments
+STAGE=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--stage STAGE_NAME]"
+      exit 1
+      ;;
+  esac
+done
+
+# Install dependencies if not already installed
+if ! command -v ts-node &> /dev/null; then
+  echo "Installing dependencies..."
+  corepack enable
+  npx projen install:ci
+fi
+
+# Function to run drift detection for a stage
+run_drift_detection() {
+  local stage_name=$1
+  local region=$2
+  local role_arn=$3
+  local stacks=$4
+  local fail_on_drift=$5
+  local error_handlers=$6
+  local env_vars=$7
+
+  echo "========================================"
+  echo "Running drift detection for stage: $stage_name"
+  echo "========================================"
+
+  # Set environment variables
+  export AWS_DEFAULT_REGION="$region"
+  export DRIFT_DETECTION_OUTPUT="drift-results-$stage_name.json"
+  eval "$env_vars"
+
+  # Assume role if provided
+  if [[ -n "$role_arn" ]]; then
+    echo "Assuming role: $role_arn"
+    CREDS=$(aws sts assume-role \\
+      --role-arn "$role_arn" \\
+      --role-session-name "drift-detection-$stage_name" \\
+      --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \\
+      --output text)
+    export AWS_ACCESS_KEY_ID=$(echo $CREDS | cut -d' ' -f1)
+    export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | cut -d' ' -f2)
+    export AWS_SESSION_TOKEN=$(echo $CREDS | cut -d' ' -f3)
+  fi
+
+  # Build command
+  local cmd="npx ts-node src/drift/detect-drift.ts --region $region"
+  
+  if [[ -n "$stacks" ]]; then
+    cmd="$cmd --stacks $stacks"
+  fi
+  
+  if [[ "$fail_on_drift" == "false" ]]; then
+    cmd="$cmd --no-fail-on-drift"
+  fi
+  
+  if [[ -n "$error_handlers" ]]; then
+    cmd="$cmd --error-handlers '$error_handlers'"
+  fi
+
+  # Run drift detection
+  echo "Running: $cmd"
+  eval "$cmd" || {
+    local exit_code=$?
+    echo "Drift detection failed with exit code: $exit_code"
+    if [[ "$fail_on_drift" == "true" ]]; then
+      return $exit_code
+    fi
+  }
+}
+
+# Stage configurations
+# Stage: production
+run_stage_production() {
+  export AWS_DEFAULT_REGION="us-east-1"
+  export DRIFT_DETECTION_OUTPUT="drift-results-production.json"
+  export AWS_REGION="us-east-1"
+  export STAGE_NAME="production"
+  detect-drift --region us-east-1
+}
+
+# Main execution
+FAILED_STAGES=()
+
+if [[ -n "$STAGE" ]]; then
+  # Run specific stage
+  case "$STAGE" in
+    production)
+      run_stage_production || FAILED_STAGES+=("production")
+      ;;
+    *)
+      echo "Unknown stage: $STAGE"
+      echo "Available stages:"
+      echo "  - production"
+      exit 1
+      ;;
+  esac
+else
+  # Run all stages
+  run_stage_production || FAILED_STAGES+=("production")
 fi
 
 # Summary
@@ -325,6 +591,218 @@ exports[`DriftDetectionStep should generate correct GitLab configuration 1`] = `
 }
 `;
 
+exports[`GitHubDriftDetectionWorkflow should auto-detect pnpm and include setup step for NodeProject with pnpm 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "pnpm exec projen".
+
+name: drift-detection
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to check for drift (leave empty for all)
+        required: false
+        type: choice
+        options:
+          - production
+jobs:
+  drift-production:
+    name: Drift Detection - production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      DRIFT_DETECTION_OUTPUT: drift-results-production.json
+      AWS_REGION: us-east-1
+      STAGE_NAME: production
+    if: \${{ github.event_name == 'schedule' || github.event.inputs.stage == '' || github.event.inputs.stage == 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "9"
+      - name: Install dependencies
+        run: pnpm exec projen install:ci
+      - run: detect-drift --region us-east-1
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-results-production
+          path: drift-results-production.json
+  drift-summary:
+    name: Drift Detection Summary
+    needs: drift-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: drift-results
+      - name: Generate summary
+        run: |
+          
+          #!/bin/bash
+          echo "## Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          total_stacks=0
+          total_drifted=0
+          total_errors=0
+
+          for file in drift-results-*.json; do
+            if [[ -f "$file" ]]; then
+              stage=$(basename $(dirname "$file"))
+              echo "### Stage: $stage" >> $GITHUB_STEP_SUMMARY
+              
+              # Parse JSON and generate summary
+              jq -r '
+                . as $results |
+                "- Total stacks: " + ($results | length | tostring) + "\\n" +
+                "- Drifted: " + ([$results[] | select(.driftStatus == "DRIFTED")] | length | tostring) + "\\n" +
+                "- Errors: " + ([$results[] | select(.error)] | length | tostring) + "\\n" +
+                ([$results[] | select(.driftStatus == "DRIFTED")] | 
+                  if length > 0 then
+                    "\\n**Drifted stacks:**\\n" + 
+                    (map("  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)") | join("\\n"))
+                  else "" end)
+              ' "$file" >> $GITHUB_STEP_SUMMARY
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              # Count totals
+              total_stacks=$((total_stacks + $(jq 'length' "$file")))
+              total_drifted=$((total_drifted + $(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")))
+              total_errors=$((total_errors + $(jq '[.[] | select(.error)] | length' "$file")))
+            fi
+          done
+
+          echo "### Overall Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Total stacks checked: $total_stacks" >> $GITHUB_STEP_SUMMARY
+          echo "- Total drifted stacks: $total_drifted" >> $GITHUB_STEP_SUMMARY
+          echo "- Total errors: $total_errors" >> $GITHUB_STEP_SUMMARY
+
+          if [[ $total_drifted -gt 0 ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Action required:** Drift detected in $total_drifted stacks" >> $GITHUB_STEP_SUMMARY
+          fi
+"
+`;
+
+exports[`GitHubDriftDetectionWorkflow should auto-detect yarn berry and include corepack setup for NodeProject with yarn berry 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "yarn projen".
+
+name: drift-detection
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to check for drift (leave empty for all)
+        required: false
+        type: choice
+        options:
+          - production
+jobs:
+  drift-production:
+    name: Drift Detection - production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      DRIFT_DETECTION_OUTPUT: drift-results-production.json
+      AWS_REGION: us-east-1
+      STAGE_NAME: production
+    if: \${{ github.event_name == 'schedule' || github.event.inputs.stage == '' || github.event.inputs.stage == 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn projen install:ci
+      - run: detect-drift --region us-east-1
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-results-production
+          path: drift-results-production.json
+  drift-summary:
+    name: Drift Detection Summary
+    needs: drift-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: drift-results
+      - name: Generate summary
+        run: |
+          
+          #!/bin/bash
+          echo "## Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          total_stacks=0
+          total_drifted=0
+          total_errors=0
+
+          for file in drift-results-*.json; do
+            if [[ -f "$file" ]]; then
+              stage=$(basename $(dirname "$file"))
+              echo "### Stage: $stage" >> $GITHUB_STEP_SUMMARY
+              
+              # Parse JSON and generate summary
+              jq -r '
+                . as $results |
+                "- Total stacks: " + ($results | length | tostring) + "\\n" +
+                "- Drifted: " + ([$results[] | select(.driftStatus == "DRIFTED")] | length | tostring) + "\\n" +
+                "- Errors: " + ([$results[] | select(.error)] | length | tostring) + "\\n" +
+                ([$results[] | select(.driftStatus == "DRIFTED")] | 
+                  if length > 0 then
+                    "\\n**Drifted stacks:**\\n" + 
+                    (map("  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)") | join("\\n"))
+                  else "" end)
+              ' "$file" >> $GITHUB_STEP_SUMMARY
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              # Count totals
+              total_stacks=$((total_stacks + $(jq 'length' "$file")))
+              total_drifted=$((total_drifted + $(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")))
+              total_errors=$((total_errors + $(jq '[.[] | select(.error)] | length' "$file")))
+            fi
+          done
+
+          echo "### Overall Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Total stacks checked: $total_stacks" >> $GITHUB_STEP_SUMMARY
+          echo "- Total drifted stacks: $total_drifted" >> $GITHUB_STEP_SUMMARY
+          echo "- Total errors: $total_errors" >> $GITHUB_STEP_SUMMARY
+
+          if [[ $total_drifted -gt 0 ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Action required:** Drift detected in $total_drifted stacks" >> $GITHUB_STEP_SUMMARY
+          fi
+"
+`;
+
 exports[`GitHubDriftDetectionWorkflow should create GitHub workflow 1`] = `
 "# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".
 
@@ -471,6 +949,220 @@ jobs:
 "
 `;
 
+exports[`GitHubDriftDetectionWorkflow should include both preInstallSteps and auto-detected package manager setup 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "pnpm exec projen".
+
+name: drift-detection
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to check for drift (leave empty for all)
+        required: false
+        type: choice
+        options:
+          - production
+jobs:
+  drift-production:
+    name: Drift Detection - production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      DRIFT_DETECTION_OUTPUT: drift-results-production.json
+      AWS_REGION: us-east-1
+      STAGE_NAME: production
+    if: \${{ github.event_name == 'schedule' || github.event.inputs.stage == '' || github.event.inputs.stage == 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Enable corepack
+        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "9"
+      - name: Install dependencies
+        run: pnpm exec projen install:ci
+      - run: detect-drift --region us-east-1
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-results-production
+          path: drift-results-production.json
+  drift-summary:
+    name: Drift Detection Summary
+    needs: drift-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: drift-results
+      - name: Generate summary
+        run: |
+          
+          #!/bin/bash
+          echo "## Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          total_stacks=0
+          total_drifted=0
+          total_errors=0
+
+          for file in drift-results-*.json; do
+            if [[ -f "$file" ]]; then
+              stage=$(basename $(dirname "$file"))
+              echo "### Stage: $stage" >> $GITHUB_STEP_SUMMARY
+              
+              # Parse JSON and generate summary
+              jq -r '
+                . as $results |
+                "- Total stacks: " + ($results | length | tostring) + "\\n" +
+                "- Drifted: " + ([$results[] | select(.driftStatus == "DRIFTED")] | length | tostring) + "\\n" +
+                "- Errors: " + ([$results[] | select(.error)] | length | tostring) + "\\n" +
+                ([$results[] | select(.driftStatus == "DRIFTED")] | 
+                  if length > 0 then
+                    "\\n**Drifted stacks:**\\n" + 
+                    (map("  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)") | join("\\n"))
+                  else "" end)
+              ' "$file" >> $GITHUB_STEP_SUMMARY
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              # Count totals
+              total_stacks=$((total_stacks + $(jq 'length' "$file")))
+              total_drifted=$((total_drifted + $(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")))
+              total_errors=$((total_errors + $(jq '[.[] | select(.error)] | length' "$file")))
+            fi
+          done
+
+          echo "### Overall Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Total stacks checked: $total_stacks" >> $GITHUB_STEP_SUMMARY
+          echo "- Total drifted stacks: $total_drifted" >> $GITHUB_STEP_SUMMARY
+          echo "- Total errors: $total_errors" >> $GITHUB_STEP_SUMMARY
+
+          if [[ $total_drifted -gt 0 ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Action required:** Drift detected in $total_drifted stacks" >> $GITHUB_STEP_SUMMARY
+          fi
+"
+`;
+
+exports[`GitHubDriftDetectionWorkflow should include corepack setup step when preInstallSteps contains CorepackSetupStep 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".
+
+name: drift-detection
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to check for drift (leave empty for all)
+        required: false
+        type: choice
+        options:
+          - production
+jobs:
+  drift-production:
+    name: Drift Detection - production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      DRIFT_DETECTION_OUTPUT: drift-results-production.json
+      AWS_REGION: us-east-1
+      STAGE_NAME: production
+    if: \${{ github.event_name == 'schedule' || github.event.inputs.stage == '' || github.event.inputs.stage == 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: npx projen install:ci
+      - run: detect-drift --region us-east-1
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-results-production
+          path: drift-results-production.json
+  drift-summary:
+    name: Drift Detection Summary
+    needs: drift-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: drift-results
+      - name: Generate summary
+        run: |
+          
+          #!/bin/bash
+          echo "## Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          total_stacks=0
+          total_drifted=0
+          total_errors=0
+
+          for file in drift-results-*.json; do
+            if [[ -f "$file" ]]; then
+              stage=$(basename $(dirname "$file"))
+              echo "### Stage: $stage" >> $GITHUB_STEP_SUMMARY
+              
+              # Parse JSON and generate summary
+              jq -r '
+                . as $results |
+                "- Total stacks: " + ($results | length | tostring) + "\\n" +
+                "- Drifted: " + ([$results[] | select(.driftStatus == "DRIFTED")] | length | tostring) + "\\n" +
+                "- Errors: " + ([$results[] | select(.error)] | length | tostring) + "\\n" +
+                ([$results[] | select(.driftStatus == "DRIFTED")] | 
+                  if length > 0 then
+                    "\\n**Drifted stacks:**\\n" + 
+                    (map("  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)") | join("\\n"))
+                  else "" end)
+              ' "$file" >> $GITHUB_STEP_SUMMARY
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              # Count totals
+              total_stacks=$((total_stacks + $(jq 'length' "$file")))
+              total_drifted=$((total_drifted + $(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")))
+              total_errors=$((total_errors + $(jq '[.[] | select(.error)] | length' "$file")))
+            fi
+          done
+
+          echo "### Overall Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Total stacks checked: $total_stacks" >> $GITHUB_STEP_SUMMARY
+          echo "- Total drifted stacks: $total_drifted" >> $GITHUB_STEP_SUMMARY
+          echo "- Total errors: $total_errors" >> $GITHUB_STEP_SUMMARY
+
+          if [[ $total_drifted -gt 0 ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Action required:** Drift detected in $total_drifted stacks" >> $GITHUB_STEP_SUMMARY
+          fi
+"
+`;
+
 exports[`GitHubDriftDetectionWorkflow should include environment variables in stages 1`] = `
 "# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".
 
@@ -509,6 +1201,120 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         run: npx projen install:ci
+      - run: detect-drift --region us-east-1
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: drift-results-production
+          path: drift-results-production.json
+  drift-summary:
+    name: Drift Detection Summary
+    needs: drift-production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: drift-results
+      - name: Generate summary
+        run: |
+          
+          #!/bin/bash
+          echo "## Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          total_stacks=0
+          total_drifted=0
+          total_errors=0
+
+          for file in drift-results-*.json; do
+            if [[ -f "$file" ]]; then
+              stage=$(basename $(dirname "$file"))
+              echo "### Stage: $stage" >> $GITHUB_STEP_SUMMARY
+              
+              # Parse JSON and generate summary
+              jq -r '
+                . as $results |
+                "- Total stacks: " + ($results | length | tostring) + "\\n" +
+                "- Drifted: " + ([$results[] | select(.driftStatus == "DRIFTED")] | length | tostring) + "\\n" +
+                "- Errors: " + ([$results[] | select(.error)] | length | tostring) + "\\n" +
+                ([$results[] | select(.driftStatus == "DRIFTED")] | 
+                  if length > 0 then
+                    "\\n**Drifted stacks:**\\n" + 
+                    (map("  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)") | join("\\n"))
+                  else "" end)
+              ' "$file" >> $GITHUB_STEP_SUMMARY
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              # Count totals
+              total_stacks=$((total_stacks + $(jq 'length' "$file")))
+              total_drifted=$((total_drifted + $(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")))
+              total_errors=$((total_errors + $(jq '[.[] | select(.error)] | length' "$file")))
+            fi
+          done
+
+          echo "### Overall Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- Total stacks checked: $total_stacks" >> $GITHUB_STEP_SUMMARY
+          echo "- Total drifted stacks: $total_drifted" >> $GITHUB_STEP_SUMMARY
+          echo "- Total errors: $total_errors" >> $GITHUB_STEP_SUMMARY
+
+          if [[ $total_drifted -gt 0 ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ **Action required:** Drift detected in $total_drifted stacks" >> $GITHUB_STEP_SUMMARY
+          fi
+"
+`;
+
+exports[`GitHubDriftDetectionWorkflow should include pnpm setup step when preInstallSteps contains PnpmSetupStep 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".
+
+name: drift-detection
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Stage to check for drift (leave empty for all)
+        required: false
+        type: choice
+        options:
+          - production
+jobs:
+  drift-production:
+    name: Drift Detection - production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      DRIFT_DETECTION_OUTPUT: drift-results-production.json
+      AWS_REGION: us-east-1
+      STAGE_NAME: production
+    if: \${{ github.event_name == 'schedule' || github.event.inputs.stage == '' || github.event.inputs.stage == 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "9"
+      - name: Install dependencies
+        run: npx projen install:ci
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/ProdRole
+          role-session-name: GitHubAction
+          aws-region: us-east-1
       - run: detect-drift --region us-east-1
       - name: Upload results
         uses: actions/upload-artifact@v7
@@ -894,7 +1700,229 @@ jobs:
 
 exports[`GitLabDriftDetectionWorkflow should add GitLab runner tags when specified 1`] = `undefined`;
 
+exports[`GitLabDriftDetectionWorkflow should auto-detect yarn berry and include corepack setup for NodeProject 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "yarn projen".
+
+stages:
+  - drift-detection
+  - summary
+.drift-detection:
+  stage: drift-detection
+  tags: []
+  image:
+    name: node:18
+  id_tokens:
+    AWS_TOKEN:
+      aud: https://sts.amazonaws.com
+  only:
+    refs:
+      - schedules
+    variables:
+      - $CI_PIPELINE_SOURCE == "schedule"
+      - $DRIFT_DETECTION == "true"
+  before_script:
+    - apt-get update && apt-get install -y python3 python3-pip
+    - pip3 install awscli
+    - corepack enable
+    - yarn projen install:ci
+  artifacts:
+    paths:
+      - drift-results-*.json
+    expire_in: 1 week
+    when: always
+drift:production:
+  extends:
+    - .drift-detection
+  variables:
+    AWS_DEFAULT_REGION: us-east-1
+    DRIFT_DETECTION_OUTPUT: drift-results-production.json
+    AWS_REGION: us-east-1
+    STAGE_NAME: production
+  script:
+    - detect-drift --region us-east-1
+  allow_failure: true
+drift:summary:
+  stage: summary
+  tags: []
+  needs:
+    - drift:production
+  only:
+    refs:
+      - schedules
+    variables:
+      - $CI_PIPELINE_SOURCE == "schedule"
+      - $DRIFT_DETECTION == "true"
+  script:
+    - echo "## Drift Detection Summary"
+    - echo ""
+    - |
+      
+      total_stacks=0
+      total_drifted=0
+      total_errors=0
+
+      for file in drift-results-*.json; do
+        if [[ -f "$file" ]]; then
+          stage=$(echo $file | sed 's/drift-results-//;s/.json//')
+          echo "### Stage: $stage"
+          
+          # Count results
+          stacks=$(jq 'length' "$file")
+          drifted=$(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")
+          errors=$(jq '[.[] | select(.error)] | length' "$file")
+          
+          echo "- Total stacks: $stacks"
+          echo "- Drifted: $drifted"
+          echo "- Errors: $errors"
+          
+          # Show drifted stacks
+          if [[ $drifted -gt 0 ]]; then
+            echo ""
+            echo "**Drifted stacks:**"
+            jq -r '.[] | select(.driftStatus == "DRIFTED") | "  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)"' "$file"
+          fi
+          
+          echo ""
+          
+          # Accumulate totals
+          total_stacks=$((total_stacks + stacks))
+          total_drifted=$((total_drifted + drifted))
+          total_errors=$((total_errors + errors))
+        fi
+      done
+
+      echo "### Overall Summary"
+      echo "- Total stacks checked: $total_stacks"
+      echo "- Total drifted stacks: $total_drifted"
+      echo "- Total errors: $total_errors"
+
+      if [[ $total_drifted -gt 0 ]]; then
+        echo ""
+        echo "⚠️ **Action required:** Drift detected in $total_drifted stacks"
+        
+        # Send notification if webhook is configured
+        if [[ -n "$DRIFT_NOTIFICATION_WEBHOOK" ]]; then
+          curl -X POST "$DRIFT_NOTIFICATION_WEBHOOK" \\
+            -H "Content-Type: application/json" \\
+            -d "{\\"text\\": \\"Drift detected in $total_drifted stacks. Check pipeline $CI_PIPELINE_URL for details.\\"}" || true
+        fi
+      fi
+  when: always
+"
+`;
+
 exports[`GitLabDriftDetectionWorkflow should create GitLab pipeline 1`] = `undefined`;
+
+exports[`GitLabDriftDetectionWorkflow should include corepack setup in beforeScript when preInstallSteps contains CorepackSetupStep 1`] = `
+"# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".
+
+stages:
+  - drift-detection
+  - summary
+.drift-detection:
+  stage: drift-detection
+  tags: []
+  image:
+    name: node:18
+  id_tokens:
+    AWS_TOKEN:
+      aud: https://sts.amazonaws.com
+  only:
+    refs:
+      - schedules
+    variables:
+      - $CI_PIPELINE_SOURCE == "schedule"
+      - $DRIFT_DETECTION == "true"
+  before_script:
+    - apt-get update && apt-get install -y python3 python3-pip
+    - pip3 install awscli
+    - corepack enable
+    - npx projen install:ci
+  artifacts:
+    paths:
+      - drift-results-*.json
+    expire_in: 1 week
+    when: always
+drift:production:
+  extends:
+    - .drift-detection
+  variables:
+    AWS_DEFAULT_REGION: us-east-1
+    DRIFT_DETECTION_OUTPUT: drift-results-production.json
+    AWS_REGION: us-east-1
+    STAGE_NAME: production
+  script:
+    - detect-drift --region us-east-1
+  allow_failure: true
+drift:summary:
+  stage: summary
+  tags: []
+  needs:
+    - drift:production
+  only:
+    refs:
+      - schedules
+    variables:
+      - $CI_PIPELINE_SOURCE == "schedule"
+      - $DRIFT_DETECTION == "true"
+  script:
+    - echo "## Drift Detection Summary"
+    - echo ""
+    - |
+      
+      total_stacks=0
+      total_drifted=0
+      total_errors=0
+
+      for file in drift-results-*.json; do
+        if [[ -f "$file" ]]; then
+          stage=$(echo $file | sed 's/drift-results-//;s/.json//')
+          echo "### Stage: $stage"
+          
+          # Count results
+          stacks=$(jq 'length' "$file")
+          drifted=$(jq '[.[] | select(.driftStatus == "DRIFTED")] | length' "$file")
+          errors=$(jq '[.[] | select(.error)] | length' "$file")
+          
+          echo "- Total stacks: $stacks"
+          echo "- Drifted: $drifted"
+          echo "- Errors: $errors"
+          
+          # Show drifted stacks
+          if [[ $drifted -gt 0 ]]; then
+            echo ""
+            echo "**Drifted stacks:**"
+            jq -r '.[] | select(.driftStatus == "DRIFTED") | "  - " + .stackName + " (" + ((.driftedResources // []) | length | tostring) + " resources)"' "$file"
+          fi
+          
+          echo ""
+          
+          # Accumulate totals
+          total_stacks=$((total_stacks + stacks))
+          total_drifted=$((total_drifted + drifted))
+          total_errors=$((total_errors + errors))
+        fi
+      done
+
+      echo "### Overall Summary"
+      echo "- Total stacks checked: $total_stacks"
+      echo "- Total drifted stacks: $total_drifted"
+      echo "- Total errors: $total_errors"
+
+      if [[ $total_drifted -gt 0 ]]; then
+        echo ""
+        echo "⚠️ **Action required:** Drift detected in $total_drifted stacks"
+        
+        # Send notification if webhook is configured
+        if [[ -n "$DRIFT_NOTIFICATION_WEBHOOK" ]]; then
+          curl -X POST "$DRIFT_NOTIFICATION_WEBHOOK" \\
+            -H "Content-Type: application/json" \\
+            -d "{\\"text\\": \\"Drift detected in $total_drifted stacks. Check pipeline $CI_PIPELINE_URL for details.\\"}" || true
+        fi
+      fi
+  when: always
+"
+`;
 
 exports[`GitLabDriftDetectionWorkflow should prefix job names with pipelineName 1`] = `
 "# ~~ Generated by projen. To modify, edit .projenrc.js and run "npx projen".

--- a/test/drift/drift-detection.test.ts
+++ b/test/drift/drift-detection.test.ts
@@ -1,5 +1,6 @@
 import { Project } from 'projen';
 import { GitHubProject } from 'projen/lib/github';
+import { NodePackageManager, NodeProject } from 'projen/lib/javascript';
 import { synthSnapshot } from 'projen/lib/util/synth';
 import {
   DriftDetectionStep,
@@ -7,6 +8,7 @@ import {
   GitLabDriftDetectionWorkflow,
   BashDriftDetectionWorkflow,
 } from '../../src/drift';
+import { PnpmSetupStep, CorepackSetupStep } from '../../src/steps';
 
 describe('DriftDetectionStep', () => {
   let project: Project;
@@ -178,6 +180,113 @@ describe('GitHubDriftDetectionWorkflow', () => {
     const snapshot = synthSnapshot(project);
     expect(snapshot['.github/workflows/drift-detection.yml']).toMatchSnapshot();
   });
+
+  it('should include pnpm setup step when preInstallSteps contains PnpmSetupStep', () => {
+    new GitHubDriftDetectionWorkflow(project, {
+      preInstallSteps: [new PnpmSetupStep(project, { version: '9' })],
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+          roleArn: 'arn:aws:iam::123456789012:role/ProdRole',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(project);
+    const workflowYml = snapshot['.github/workflows/drift-detection.yml'];
+    expect(workflowYml).toContain('pnpm/action-setup@v4');
+    expect(workflowYml).toMatchSnapshot();
+  });
+
+  it('should include corepack setup step when preInstallSteps contains CorepackSetupStep', () => {
+    new GitHubDriftDetectionWorkflow(project, {
+      preInstallSteps: [new CorepackSetupStep(project)],
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(project);
+    const workflowYml = snapshot['.github/workflows/drift-detection.yml'];
+    expect(workflowYml).toContain('corepack enable');
+    expect(workflowYml).toMatchSnapshot();
+  });
+
+  it('should auto-detect pnpm and include setup step for NodeProject with pnpm', () => {
+    const pnpmProject = new NodeProject({
+      name: 'pnpm-project',
+      defaultReleaseBranch: 'main',
+      packageManager: NodePackageManager.PNPM,
+      pnpmVersion: '9',
+    });
+
+    new GitHubDriftDetectionWorkflow(pnpmProject, {
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(pnpmProject);
+    const workflowYml = snapshot['.github/workflows/drift-detection.yml'];
+    expect(workflowYml).toContain('pnpm/action-setup@v4');
+    expect(workflowYml).toMatchSnapshot();
+  });
+
+  it('should auto-detect yarn berry and include corepack setup for NodeProject with yarn berry', () => {
+    const yarnProject = new NodeProject({
+      name: 'yarn-berry-project',
+      defaultReleaseBranch: 'main',
+      packageManager: NodePackageManager.YARN_BERRY,
+    });
+
+    new GitHubDriftDetectionWorkflow(yarnProject, {
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(yarnProject);
+    const workflowYml = snapshot['.github/workflows/drift-detection.yml'];
+    expect(workflowYml).toContain('corepack enable');
+    expect(workflowYml).toMatchSnapshot();
+  });
+
+  it('should include both preInstallSteps and auto-detected package manager setup', () => {
+    const pnpmProject = new NodeProject({
+      name: 'pnpm-project',
+      defaultReleaseBranch: 'main',
+      packageManager: NodePackageManager.PNPM,
+      pnpmVersion: '9',
+    });
+
+    new GitHubDriftDetectionWorkflow(pnpmProject, {
+      preInstallSteps: [new CorepackSetupStep(pnpmProject)],
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(pnpmProject);
+    const workflowYml = snapshot['.github/workflows/drift-detection.yml'];
+    // preInstallSteps should be included
+    expect(workflowYml).toContain('corepack enable');
+    // auto-detected pnpm setup should also be included
+    expect(workflowYml).toContain('pnpm/action-setup@v4');
+    expect(workflowYml).toMatchSnapshot();
+  });
 });
 
 describe('GitLabDriftDetectionWorkflow', () => {
@@ -260,6 +369,49 @@ describe('GitLabDriftDetectionWorkflow', () => {
     const snapshot = synthSnapshot(project);
     expect(snapshot['.gitlab/drift-detection.yml']).toMatchSnapshot();
   });
+
+  it('should include corepack setup in beforeScript when preInstallSteps contains CorepackSetupStep', () => {
+    new GitLabDriftDetectionWorkflow(project, {
+      preInstallSteps: [new CorepackSetupStep(project)],
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(project);
+    const gitlabCiKey = Object.keys(snapshot).find(k => k.includes('gitlab'));
+    expect(gitlabCiKey).toBeDefined();
+    const gitlabCi = snapshot[gitlabCiKey!];
+    expect(gitlabCi).toContain('corepack enable');
+    expect(gitlabCi).toMatchSnapshot();
+  });
+
+  it('should auto-detect yarn berry and include corepack setup for NodeProject', () => {
+    const yarnProject = new NodeProject({
+      name: 'yarn-berry-project',
+      defaultReleaseBranch: 'main',
+      packageManager: NodePackageManager.YARN_BERRY,
+    });
+
+    new GitLabDriftDetectionWorkflow(yarnProject, {
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(yarnProject);
+    const gitlabCiKey = Object.keys(snapshot).find(k => k.includes('gitlab'));
+    expect(gitlabCiKey).toBeDefined();
+    const gitlabCi = snapshot[gitlabCiKey!];
+    expect(gitlabCi).toContain('corepack enable');
+    expect(gitlabCi).toMatchSnapshot();
+  });
 });
 
 describe('BashDriftDetectionWorkflow', () => {
@@ -303,5 +455,45 @@ describe('BashDriftDetectionWorkflow', () => {
 
     const snapshot = synthSnapshot(project);
     expect(snapshot['scripts/check-drift.sh']).toMatchSnapshot();
+  });
+
+  it('should include corepack setup when preInstallSteps contains CorepackSetupStep', () => {
+    new BashDriftDetectionWorkflow(project, {
+      preInstallSteps: [new CorepackSetupStep(project)],
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(project);
+    const script = snapshot['drift-detection.sh'];
+    expect(script).toContain('corepack enable');
+    expect(script).toMatchSnapshot();
+  });
+
+  it('should auto-detect pnpm and include pnpm install for NodeProject with pnpm', () => {
+    const pnpmProject = new NodeProject({
+      name: 'pnpm-project',
+      defaultReleaseBranch: 'main',
+      packageManager: NodePackageManager.PNPM,
+      pnpmVersion: '9',
+    });
+
+    new BashDriftDetectionWorkflow(pnpmProject, {
+      stages: [
+        {
+          name: 'production',
+          region: 'us-east-1',
+        },
+      ],
+    });
+
+    const snapshot = synthSnapshot(pnpmProject);
+    const script = snapshot['drift-detection.sh'];
+    expect(script).toContain('npm install -g pnpm@9');
+    expect(script).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Fixes #202 — pnpm setup step missing in Drift Detection workflows.

### Problem

The drift detection workflows generated `install:ci` and "Setup Node.js" steps assuming a Node project, but didn't set up pnpm or Yarn Berry before running `install:ci`. For projects using pnpm as their package manager, the install step would fail because pnpm wasn't available.

### Solution

The `DriftDetectionWorkflow` base class now **automatically detects** the project's package manager from the `NodeProject.package` property and injects the appropriate setup steps:

- **pnpm**: Adds `PnpmSetupStep` (uses `pnpm/action-setup@v4` on GitHub, `npm install -g pnpm@<version>` on GitLab/Bash)
- **Yarn Berry**: Adds `CorepackSetupStep` (runs `corepack enable`)

No manual configuration is needed — it just works when the project is a `NodeProject` (or subclass like `AwsCdkTypeScriptApp`).

### Key Design Decision

`preInstallSteps` adds steps **before install without overwriting** the auto-detected package manager setup. Both user-provided and auto-detected steps are included:

```typescript
this.preInstallSteps = [
  ...(options.preInstallSteps ?? []),    // user-provided steps
  ...this.detectPackageManagerSteps(project),  // auto-detected steps
];
```

### Additional Changes

- Added `toGitlab()` and `toBash()` methods to `PnpmSetupStep` so pnpm setup works across all CI engines (not just GitHub Actions)
- Added `preInstallSteps` option to `DriftDetectionWorkflowOptions` for additional pre-install steps
- Added tests verifying auto-detection for pnpm and Yarn Berry across all three engines
- Added test verifying `preInstallSteps` coexists with auto-detected package manager setup

### Usage

For pnpm projects, the setup step is now automatically included:

```typescript
// NodeProject with pnpm — pnpm setup is auto-detected
const project = new AwsCdkTypeScriptApp({
  name: 'my-app',
  packageManager: NodePackageManager.PNPM,
  pnpmVersion: '9',
  // ...
});

// No preInstallSteps needed — pnpm setup is automatic!
new GitHubDriftDetectionWorkflow(project, {
  stages: [{ name: 'production', region: 'us-east-1', roleArn: '...' }],
});
```

Additional pre-install steps can still be added without overriding the package manager setup:

```typescript
new GitHubDriftDetectionWorkflow(project, {
  preInstallSteps: [new SomeCustomStep(project)],  // added alongside pnpm setup
  stages: [...],
});
```

### Testing

- All 199 tests pass
- New tests verify auto-detection for pnpm (GitHub + Bash) and Yarn Berry (GitHub + GitLab)
- New test verifies `preInstallSteps` doesn't override auto-detected package manager setup