### PR TITLE
fix: include workflow file path in paths trigger for monorepos

### DIFF
--- a/src/awscdk/github.ts
+++ b/src/awscdk/github.ts
@@ -10,6 +10,7 @@ import { CdkOutputsSummaryStep } from '../steps/github-summary.step';
 import { GithubPackagesLoginStep } from '../steps/registries';
 
 const DEFAULT_RUNNER_TAGS = ['ubuntu-latest'];
+const WORKFLOW_DIR = '.github/workflows';
 
 
 /**
@@ -97,7 +98,7 @@ export class GithubCDKPipeline extends CDKPipeline {
     this.deploymentWorkflow.on({
       push: {
         branches: [this.branchName],
-        ...this.baseOptions.paths && { paths: this.baseOptions.paths },
+        ...this.baseOptions.paths && { paths: this.pathsWithWorkflowFile('deploy') },
       },
       workflowDispatch: {},
     });
@@ -146,6 +147,16 @@ export class GithubCDKPipeline extends CDKPipeline {
   }
 
   /**
+   * Returns the paths filter array with the workflow file itself included.
+   * This ensures that changes to the workflow file also trigger the pipeline.
+   * @param workflowName - The name of the workflow (used to derive the file path).
+   */
+  private pathsWithWorkflowFile(workflowName: string): string[] {
+    const workflowFilePath = `${WORKFLOW_DIR}/${this.namePrefix}${workflowName}.yml`;
+    return [...this.baseOptions.paths!, workflowFilePath];
+  }
+
+  /**
    * Returns the artifact path prefixed with workingDirectory if set.
    * Artifact upload/download paths resolve against GITHUB_WORKSPACE,
    * not the job working-directory, so they must be prefixed explicitly.
@@ -188,7 +199,7 @@ export class GithubCDKPipeline extends CDKPipeline {
     workflow.on({
       pullRequestTarget: {
         types: ['synchronize', 'labeled', 'opened', 'reopened'],
-        ...this.baseOptions.paths && { paths: this.baseOptions.paths },
+        ...this.baseOptions.paths && { paths: this.pathsWithWorkflowFile('deploy-feature') },
       },
       workflowDispatch: {},
     });
@@ -247,7 +258,7 @@ export class GithubCDKPipeline extends CDKPipeline {
     workflow.on({
       pullRequestTarget: {
         types: ['closed', 'unlabeled'],
-        ...this.baseOptions.paths && { paths: this.baseOptions.paths },
+        ...this.baseOptions.paths && { paths: this.pathsWithWorkflowFile('destroy-feature') },
       },
       workflowDispatch: {},
     });

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -4727,6 +4727,7 @@ on:
     paths:
       - packages/my-app/**
       - shared-libs/**
+      - .github/workflows/deploy.yml
   workflow_dispatch: {}
 jobs:
   synth:
@@ -4868,6 +4869,7 @@ on:
       - main
     paths:
       - packages/my-app/**
+      - .github/workflows/deploy.yml
   workflow_dispatch: {}
 jobs:
   synth:
@@ -5005,6 +5007,7 @@ on:
       - reopened
     paths:
       - packages/my-app/**
+      - .github/workflows/deploy-feature.yml
   workflow_dispatch: {}
 jobs:
   synth-and-deploy:
@@ -5082,6 +5085,7 @@ on:
       - unlabeled
     paths:
       - packages/my-app/**
+      - .github/workflows/destroy-feature.yml
   workflow_dispatch: {}
 jobs:
   destroy-feature:


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

When `paths` filters are configured (e.g. for monorepo subprojects), the generated workflow files themselves were not included in the paths list. This meant that changes to the workflow file (e.g. from `npx projen` synth) would not trigger the pipeline.

## Changes

- Added a `pathsWithWorkflowFile()` helper method that appends the workflow's own file path (`.github/workflows/<namePrefix><workflowName>.yml`) to the configured paths array
- Updated the deploy, deploy-feature, and destroy-feature workflow triggers to use this helper
- Updated test snapshots to reflect the new paths entries

## Example

For a monorepo with `paths: ['packages/my-app/**']`, the deploy workflow trigger now becomes:

```yaml
on:
  push:
    branches:
      - main
    paths:
      - packages/my-app/**
      - .github/workflows/deploy.yml
```

For a prefixed pipeline (e.g. `namePrefix: 'backend-'`), it would include `.github/workflows/backend-deploy.yml`.

## Testing

- All 199 existing tests pass
- 4 snapshots updated to include the new workflow file paths

Fixes #206