### PR TITLE
fix: replace ~version.json with .version.tmp.json

### DIFF
--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -884,7 +884,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {

--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -884,7 +884,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {

--- a/src/versioning/setup.ts
+++ b/src/versioning/setup.ts
@@ -147,7 +147,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -162,7 +162,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"`;
   }
 }

--- a/src/versioning/setup.ts
+++ b/src/versioning/setup.ts
@@ -132,7 +132,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);

--- a/src/versioning/setup.ts
+++ b/src/versioning/setup.ts
@@ -23,7 +23,7 @@ export class VersioningSetup {
     this.integrateWithBuildProcess();
 
     // Add version file to gitignore
-    this.project.gitignore.exclude('~version.json');
+    this.project.gitignore.exclude('.version.tmp.json');
   }
 
   /**
@@ -48,7 +48,7 @@ export class VersioningSetup {
     this.project.addTask('version:print', {
       description: 'Print version information',
       steps: [
-        { exec: 'cat ~version.json' },
+        { exec: 'cat ./.version.tmp.json' },
       ],
     });
   }
@@ -132,7 +132,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -147,7 +147,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -162,7 +162,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"`;
   }
 }

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -1085,7 +1085,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -423,7 +423,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -423,7 +423,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -1085,7 +1085,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -1100,7 +1100,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -1115,7 +1115,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -1143,7 +1143,7 @@ try {
       "name": "version:print",
       "steps": [
         {
-          "exec": "cat ~version.json",
+          "exec": "cat ./.version.tmp.json",
         },
       ],
     },

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -1100,7 +1100,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -1115,7 +1115,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3059,7 +3059,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -5706,7 +5706,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -6688,7 +6688,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3721,7 +3721,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -6368,7 +6368,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -7350,7 +7350,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3059,7 +3059,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -3721,7 +3721,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -3736,7 +3736,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -3751,7 +3751,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -3779,7 +3779,7 @@ try {
       "name": "version:print",
       "steps": [
         {
-          "exec": "cat ~version.json",
+          "exec": "cat ./.version.tmp.json",
         },
       ],
     },
@@ -5706,7 +5706,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -6368,7 +6368,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -6383,7 +6383,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -6398,7 +6398,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -6426,7 +6426,7 @@ try {
       "name": "version:print",
       "steps": [
         {
-          "exec": "cat ~version.json",
+          "exec": "cat ./.version.tmp.json",
         },
       ],
     },
@@ -6688,7 +6688,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -7350,7 +7350,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -7365,7 +7365,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -7380,7 +7380,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -7408,7 +7408,7 @@ try {
       "name": "version:print",
       "steps": [
         {
-          "exec": "cat ~version.json",
+          "exec": "cat ./.version.tmp.json",
         },
       ],
     },

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3736,7 +3736,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -3751,7 +3751,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -6383,7 +6383,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -6398,7 +6398,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -7365,7 +7365,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -7380,7 +7380,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -1605,7 +1605,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -1605,7 +1605,7 @@ export interface VersionInfo {
  */
 export function loadVersionInfo(): VersionInfo {
   try {
-    return JSON.parse(fs.readFileSync('~version.json', 'utf8'));
+    return JSON.parse(fs.readFileSync('./.version.tmp.json', 'utf8'));
   } catch (error) {
     console.warn('Could not load version info, using fallback');
     return {
@@ -2267,7 +2267,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('~version.json', versionInfo.toJson());
+    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);
@@ -2282,7 +2282,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -2297,7 +2297,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('~version.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],
@@ -2325,7 +2325,7 @@ try {
       "name": "version:print",
       "steps": [
         {
-          "exec": "cat ~version.json",
+          "exec": "cat ./.version.tmp.json",
         },
       ],
     },

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -2282,7 +2282,7 @@ try {
       deployedBy: 'unknown',
       environment: 'unknown'
     };
-    fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+    fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
   });
 } catch (e) {
   console.error('Error in version computation:', e.message);
@@ -2297,7 +2297,7 @@ try {
     deployedBy: 'unknown',
     environment: 'unknown'
   };
-  fs.writeFileSync('./.version.tmp.json', JSON.stringify(fallback, null, 2));
+  fs.writeFileSync('.version.tmp.json', JSON.stringify(fallback, null, 2));
 }"",
         },
       ],

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -2267,7 +2267,7 @@ try {
   // Compute version
   const computer = new VersionComputer(strategy);
   computer.computeVersionInfo(context).then(versionInfo => {
-    fs.writeFileSync('./.version.tmp.json', versionInfo.toJson());
+    fs.writeFileSync('.version.tmp.json', versionInfo.toJson());
     console.log('Version computed:', versionInfo.version, '(commit:', versionInfo.commitHashShort + ')');
   }).catch(error => {
     console.error('Error computing version:', error.message);

--- a/test/bash.test.ts
+++ b/test/bash.test.ts
@@ -110,7 +110,7 @@ test('Bash snapshot with versioning enabled', () => {
   expect(snapshot['src/app.ts']).toMatchSnapshot();
   expect(snapshot['package.json']).toMatchSnapshot();
   expect(snapshot['.projen/tasks.json']).toMatchSnapshot();
-  expect(snapshot['.gitignore']).toContain('~version.json');
+  expect(snapshot['.gitignore']).toContain('.version.tmp.json');
 
   // Verify versioning code is generated in app.ts
   expect(snapshot['src/app.ts']).toContain('loadVersionInfo');


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

The `~version.json` filename breaks in shell contexts because `~` is subject to tilde expansion. This renames the temporary version file to `.version.tmp.json` and references it with a leading `./` in shell commands.

## Changes

- **`src/versioning/setup.ts`** — renamed all occurrences: `.gitignore.exclude`, the `cat` shell command, and all `fs.writeFileSync` calls
- **`src/awscdk/base.ts`** — updated `loadVersionInfo()` to read from `./.version.tmp.json`
- **`test/bash.test.ts`** — updated explicit assertion
- **Snapshots** — regenerated for bash, github, and gitlab test suites

## Testing

All 199 tests pass, all 119 snapshots pass.