### PR TITLE
feat: use node: prefix for Node.js built-in module imports

### DIFF
--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 import { Component, TextFile, awscdk } from 'projen';
 import { PROJEN_MARKER } from 'projen/lib/common';
 import { NodePackageManager } from 'projen/lib/javascript';
@@ -854,7 +854,7 @@ ${appCode}
 
     imports.push("import { CfnOutput } from 'aws-cdk-lib';");
     imports.push("import { StringParameter } from 'aws-cdk-lib/aws-ssm';");
-    imports.push("import * as fs from 'fs';");
+    imports.push("import * as fs from 'node:fs';");
 
     return imports.join('\n');
   }

--- a/src/drift/detect-drift.ts
+++ b/src/drift/detect-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 
 interface DriftDetectionOptions {
   region: string;

--- a/src/drift/github.ts
+++ b/src/drift/github.ts
@@ -127,7 +127,7 @@ export class GitHubDriftDetectionWorkflow extends DriftDetectionWorkflow {
 
   private generateIssueCreationScript(stage: DriftDetectionStageOptions): string {
     return `
-const fs = require('fs');
+const fs = require('node:fs');
 const resultsFile = '${this.namePrefix}drift-results-${stage.name}.json';
 
 if (!fs.existsSync(resultsFile)) {

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { copyFileSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 // @ts-ignore
 import ctv from 'commit-and-tag-version';
 

--- a/src/versioning/setup.ts
+++ b/src/versioning/setup.ts
@@ -74,8 +74,8 @@ export class VersioningSetup {
     const strategyJson = JSON.stringify(this.config.strategy).replace(/"/g, '\\"');
 
     return `node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -379,7 +379,7 @@ exports[`Bash snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -1101,8 +1101,8 @@ exports[`Bash snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -3431,7 +3431,7 @@ exports[`Github snapshot with jump roles 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -4153,8 +4153,8 @@ exports[`Github snapshot with jump roles 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');
@@ -6432,7 +6432,7 @@ exports[`Github snapshot with separate asset upload jobs 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -7154,8 +7154,8 @@ exports[`Github snapshot with separate asset upload jobs 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');
@@ -7513,7 +7513,7 @@ exports[`Github snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -8235,8 +8235,8 @@ exports[`Github snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -1561,7 +1561,7 @@ exports[`Gitlab snapshot with versioning enabled 2`] = `
 import { App, AppProps, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 const versioningConfig = {
   "enabled": true,
@@ -2283,8 +2283,8 @@ exports[`Gitlab snapshot with versioning enabled 4`] = `
         },
         {
           "exec": "node -e "
-const fs = require('fs');
-const cp = require('child_process');
+const fs = require('node:fs');
+const cp = require('node:child_process');
 
 // Import versioning modules
 const { VersionComputer, VersioningStrategy } = require('projen-pipelines');


### PR DESCRIPTION

Replace bare specifiers for Node.js built-in modules (fs, path,
child_process) with the standards-compliant `node:` scheme, both in the
library's own imports and in the code strings it generates for consuming
projects.

The `node:` prefix is the official convention for built-ins (Node 14.18+):
it makes intent explicit, removes ambiguity with a same-named npm package,
and lets the runtime resolve built-ins without a filesystem lookup.

Changes:
- src/awscdk/base.ts: top-level `import * as path from 'path'` and the
  generated CDK-app string `import * as fs from 'fs'` -> node: forms
- src/drift/detect-drift.ts: child_process and fs imports -> node: forms
- src/release.ts: fs and path imports -> node: forms
- src/versioning/setup.ts: generated `require('fs')` / `require('child_process')`
  strings -> node: forms
- src/drift/github.ts: generated `require('fs')` string -> node: form

Third-party imports (aws-cdk-lib, projen, undici, simple-git) are unchanged.
Generated-workflow snapshots (bash/github/gitlab) updated to reflect the
node: prefix in emitted code. All 199 tests pass; jsii compiles clean.